### PR TITLE
Add portable PC runtime alongside 3DS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tools/3DS-Decomp-Pipeline/
 tools/3ds-Ghidra-Scripts/
 .decomp/
 build/
+game-data/
 *.o
 *.elf
 *.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,143 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(pokemoon_pc VERSION 0.1.0 LANGUAGES CXX)
+
+find_package(SDL2 REQUIRED CONFIG)
+find_package(OpenGL REQUIRED)
+
+option(POKEMOON_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+option(PC_STARTUP_LANGUAGE "Enable the reconstructed fresh-profile language selector" OFF)
+if(PC_STARTUP_LANGUAGE)
+    find_package(SDL2_ttf REQUIRED CONFIG)
+endif()
+
+add_library(pokemoon_portable_core STATIC
+    src/gfl2/math/random.cpp
+    src/savedata/box_accessors.cpp
+    src/savedata/egg_clear.cpp
+    src/savedata/is_egg_exist.cpp
+    src/savedata/situation_accessors.cpp
+)
+target_include_directories(pokemoon_portable_core PUBLIC include)
+target_compile_features(pokemoon_portable_core PUBLIC cxx_std_17)
+
+add_library(pokemoon_platform STATIC
+    pc/src/frame_manager.cpp
+    pc/src/game_manager.cpp
+    pc/src/platform.cpp
+    pc/src/process_manager.cpp
+)
+target_include_directories(pokemoon_platform PUBLIC pc/include)
+target_compile_features(pokemoon_platform PUBLIC cxx_std_17)
+target_link_libraries(pokemoon_platform PUBLIC SDL2::SDL2 OpenGL::GL)
+
+add_library(pokemoon_application STATIC
+    pc/src/application.cpp
+    pc/src/startup_language.cpp
+    pc/src/title_resources.cpp
+)
+target_include_directories(pokemoon_application PUBLIC pc/include)
+target_compile_features(pokemoon_application PUBLIC cxx_std_17)
+target_link_libraries(pokemoon_application PUBLIC pokemoon_portable_core pokemoon_platform)
+if(PC_STARTUP_LANGUAGE)
+    target_compile_definitions(pokemoon_application PRIVATE PC_STARTUP_LANGUAGE=1)
+    target_link_libraries(pokemoon_application PUBLIC SDL2_ttf::SDL2_ttf)
+endif()
+
+add_executable(pokemoon-pc
+    pc/src/main.cpp
+)
+target_include_directories(pokemoon-pc PRIVATE pc/include)
+target_compile_features(pokemoon-pc PRIVATE cxx_std_17)
+target_link_libraries(pokemoon-pc PRIVATE pokemoon_application)
+
+foreach(target pokemoon_portable_core pokemoon_platform pokemoon_application pokemoon-pc)
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(${target} PRIVATE -fsanitize=address,undefined)
+    endif()
+endforeach()
+
+include(CTest)
+if(BUILD_TESTING)
+    add_test(NAME native_bootstrap COMMAND pokemoon-pc --frames 3 --no-sleep --headless)
+    add_executable(game_manager_test pc/tests/game_manager_test.cpp)
+    target_include_directories(game_manager_test PRIVATE pc/include)
+    target_compile_features(game_manager_test PRIVATE cxx_std_17)
+    target_compile_options(game_manager_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(game_manager_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(game_manager_test PRIVATE -fsanitize=address,undefined)
+    endif()
+    target_link_libraries(game_manager_test PRIVATE pokemoon_platform)
+    add_test(NAME game_manager_lifecycle COMMAND game_manager_test)
+
+    add_executable(scheduler_test pc/tests/scheduler_test.cpp)
+    target_include_directories(scheduler_test PRIVATE pc/include)
+    target_compile_features(scheduler_test PRIVATE cxx_std_17)
+    target_compile_options(scheduler_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(scheduler_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(scheduler_test PRIVATE -fsanitize=address,undefined)
+    endif()
+    target_link_libraries(scheduler_test PRIVATE pokemoon_platform)
+    add_test(NAME scheduler_lifecycle COMMAND scheduler_test)
+
+    add_executable(title_input_test pc/tests/title_input_test.cpp)
+    target_include_directories(title_input_test PRIVATE pc/include)
+    target_compile_features(title_input_test PRIVATE cxx_std_17)
+    target_compile_options(title_input_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(title_input_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(title_input_test PRIVATE -fsanitize=address,undefined)
+    endif()
+    target_link_libraries(title_input_test PRIVATE pokemoon_application SDL2::SDL2)
+    if(NOT PC_STARTUP_LANGUAGE)
+        add_test(NAME title_native_input_transition COMMAND title_input_test)
+    endif()
+
+    add_executable(title_resources_test pc/tests/title_resources_test.cpp)
+    target_include_directories(title_resources_test PRIVATE pc/include)
+    target_compile_features(title_resources_test PRIVATE cxx_std_17)
+    target_compile_options(title_resources_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(title_resources_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(title_resources_test PRIVATE -fsanitize=address,undefined)
+    endif()
+    target_link_libraries(title_resources_test PRIVATE pokemoon_application)
+    add_test(NAME title_retail_resource_decode COMMAND title_resources_test)
+
+    add_executable(startup_language_test pc/tests/startup_language_test.cpp)
+    target_include_directories(startup_language_test PRIVATE pc/include)
+    target_compile_features(startup_language_test PRIVATE cxx_std_17)
+    target_compile_options(startup_language_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+    if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(startup_language_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+        target_link_options(startup_language_test PRIVATE -fsanitize=address,undefined)
+    endif()
+    target_link_libraries(startup_language_test PRIVATE pokemoon_application)
+    add_test(NAME startup_language_profile COMMAND startup_language_test)
+
+    if(PC_STARTUP_LANGUAGE)
+        add_executable(startup_language_process_test pc/tests/startup_language_process_test.cpp)
+        target_include_directories(startup_language_process_test PRIVATE pc/include)
+        target_compile_features(startup_language_process_test PRIVATE cxx_std_17)
+        target_compile_options(startup_language_process_test PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion)
+        if(POKEMOON_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(startup_language_process_test PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+            target_link_options(startup_language_process_test PRIVATE -fsanitize=address,undefined)
+        endif()
+        target_link_libraries(startup_language_process_test PRIVATE pokemoon_application SDL2::SDL2)
+        add_test(NAME startup_language_process_transition COMMAND startup_language_process_test)
+    endif()
+
+    if(NOT PC_STARTUP_LANGUAGE)
+        add_test(
+            NAME title_process_120_frames
+            COMMAND ${CMAKE_COMMAND}
+                -DPOKEMOON_PROGRAM=$<TARGET_FILE:pokemoon-pc>
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/pc/tests/title_process_smoke.cmake
+        )
+    endif()
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,28 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/linux-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "linux-debug",
+      "configurePreset": "linux-debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "linux-debug",
+      "configurePreset": "linux-debug",
+      "output": {"outputOnFailure": true}
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -88,9 +88,42 @@ make verify
 Semantic runtime images use only explicitly runtime-ready functions. See
 `docs/BUILD.md` for the complete build workflow.
 
+### Portable PC runtime
+
+The repository also provides an independent CMake target for the native PC
+runtime. It uses SDL2/OpenGL for host input and rendering while sharing portable
+reconstructed game logic. This target does not participate in the Nintendo 3DS
+`Makefile` build and does not replace any 3DS rendering code.
+
+Linux requirements are CMake 3.20 or newer, a C++17 compiler, SDL2, OpenGL, and
+Ninja. SDL2_ttf is required only when the optional fresh-profile language
+selector is enabled.
+
+```sh
+cmake --preset linux-debug
+cmake --build --preset linux-debug
+ctest --preset linux-debug
+```
+
+Enable the startup language selector with a separate build directory:
+
+```sh
+cmake -S . -B build/linux-language -G Ninja \
+  -DCMAKE_BUILD_TYPE=Debug -DPC_STARTUP_LANGUAGE=ON
+cmake --build build/linux-language
+ctest --test-dir build/linux-language --output-on-failure
+```
+
+Run `build/linux-debug/pokemoon-pc` with `--headless` for a session without a
+window. Use `--data-root <path>`, `POKEMOON_DATA_DIR`, or
+`POKEMOON_DATA_ROOT` to select external data. Retail resources remain external
+and use ID-preserving paths such as `romfs/arc/AAAA/DDDD.bin` under the selected
+data root.
+
 ## Repository layout
 
 - `src/`, `include/`: reconstructed source and declarations
+- `pc/`: portable host runtime, platform adapters, and tests
 - `config/reconstructed_functions.csv`: authoritative function manifest
 - `symbols/`: recovered symbols and compatibility status
 - `analysis/`: function catalogs, queues, and compact progress reports

--- a/pc/include/pokemoon/application.hpp
+++ b/pc/include/pokemoon/application.hpp
@@ -1,0 +1,58 @@
+#ifndef POKEMOON_PC_APPLICATION_HPP
+#define POKEMOON_PC_APPLICATION_HPP
+
+#include "gfl2/math/random.hpp"
+#include "pokemoon/game_manager.hpp"
+#include "pokemoon/process_manager.hpp"
+#include "pokemoon/startup_language.hpp"
+#include "savedata/box.hpp"
+#include "savedata/situation.hpp"
+#include "pokemoon/platform.hpp"
+
+#include <cstdint>
+#include <memory>
+
+namespace PokemonMoon {
+
+enum class StartupPoint {
+    HostEntry,
+    PlatformReady,
+    ReconstructedCoreReady,
+    GameManagerReady,
+    NativeSchedulerReady,
+};
+
+class Application {
+public:
+    explicit Application(Platform::Runtime& platform);
+
+    bool initialize();
+    void shutdown();
+    void update();
+    StartupPoint startup_point() const;
+    std::uint64_t frame_count() const;
+
+private:
+    class TitleMenuFrameCell;
+    class TitleMenuProcess;
+    class StartupLanguageProcess;
+
+    void run_native_frame();
+    void apply_startup_language_profile(StartupLanguageProfile profile);
+
+    Platform::Runtime& platform_;
+    gfl2::math::Random random_{};
+    Savedata::Situation situation_{};
+    Savedata::BOX box_{};
+    std::unique_ptr<GameSys::GameManager> game_manager_;
+    gfl2::proc::Manager process_manager_;
+    StartupPoint startup_point_ = StartupPoint::HostEntry;
+    std::uint64_t frame_count_ = 0;
+    StartupLanguageProfile startup_language_profile_{};
+};
+
+const char* startup_point_name(StartupPoint point);
+
+} // namespace PokemonMoon
+
+#endif

--- a/pc/include/pokemoon/frame_manager.hpp
+++ b/pc/include/pokemoon/frame_manager.hpp
@@ -1,0 +1,80 @@
+#ifndef POKEMOON_PC_FRAME_MANAGER_HPP
+#define POKEMOON_PC_FRAME_MANAGER_HPP
+
+#include <cstdint>
+#include <memory>
+
+namespace applib::frame {
+
+enum class CallbackResult {
+    Continue = 0,
+    Advance = 1,
+    AdvanceNextFrame = 2,
+};
+
+enum class ManagerResult {
+    Empty = 0,
+    Running = 1,
+    Transition = 2,
+    Pushed = 3,
+};
+
+enum class CellState {
+    Created = 0,
+    Initializing = 1,
+    Running = 2,
+    Ending = 3,
+    Complete = 4,
+    Returned = 5,
+};
+
+class CellSuper {
+public:
+    virtual ~CellSuper() = default;
+
+    virtual CallbackResult initialize() = 0;
+    virtual CallbackResult update() = 0;
+    virtual void draw(std::uint32_t display) = 0;
+    virtual CallbackResult end() = 0;
+};
+
+class Manager {
+public:
+    Manager();
+    ~Manager();
+
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+
+    bool call_proc(std::unique_ptr<CellSuper> cell);
+    bool parallel_proc(std::unique_ptr<CellSuper> cell);
+    ManagerResult main();
+    bool end();
+    void draw(std::uint32_t display);
+
+    CellSuper* current_cell();
+    const CellSuper* current_cell() const;
+    CellState current_state() const;
+    bool empty() const;
+
+private:
+    struct Node;
+    enum class PendingMode {
+        None,
+        Call,
+        Parallel,
+    };
+
+    void install_pending();
+    CallbackResult update_active(Node& node);
+    void draw_active(Node& node, std::uint32_t display);
+    ManagerResult finish_current(CallbackResult result);
+
+    std::unique_ptr<Node> current_;
+    std::unique_ptr<CellSuper> pending_;
+    PendingMode pending_mode_ = PendingMode::None;
+};
+
+} // namespace applib::frame
+
+#endif

--- a/pc/include/pokemoon/game_manager.hpp
+++ b/pc/include/pokemoon/game_manager.hpp
@@ -1,0 +1,45 @@
+#ifndef POKEMOON_PC_GAME_MANAGER_HPP
+#define POKEMOON_PC_GAME_MANAGER_HPP
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+
+namespace GameSys {
+
+struct BufferClearSetting {
+    std::array<float, 4> color{};
+    float depth = 1.0f;
+    std::uint8_t stencil = 0xff;
+    std::uint8_t clear_mask = 0x03;
+};
+
+class GameManager final {
+public:
+    static constexpr std::size_t ChildHeapSize = 0x5000;
+    static constexpr std::size_t DisplayCount = 3;
+
+    GameManager();
+    ~GameManager();
+
+    GameManager(const GameManager&) = delete;
+    GameManager& operator=(const GameManager&) = delete;
+    GameManager(GameManager&&) = delete;
+    GameManager& operator=(GameManager&&) = delete;
+
+    static GameManager* instance();
+    std::pmr::memory_resource& heap();
+    bool get_buffer_clear_setting(std::size_t display, BufferClearSetting& setting) const;
+    bool set_buffer_clear_setting(std::size_t display, const BufferClearSetting& setting);
+
+private:
+    static GameManager* instance_;
+    alignas(std::max_align_t) std::array<std::byte, ChildHeapSize> heap_storage_{};
+    std::pmr::monotonic_buffer_resource heap_;
+    std::array<BufferClearSetting, DisplayCount> buffer_clear_settings_{};
+};
+
+} // namespace GameSys
+
+#endif

--- a/pc/include/pokemoon/platform.hpp
+++ b/pc/include/pokemoon/platform.hpp
@@ -1,0 +1,142 @@
+#ifndef POKEMOON_PC_PLATFORM_HPP
+#define POKEMOON_PC_PLATFORM_HPP
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Platform {
+
+enum class Button : std::uint8_t {
+    A,
+    B,
+    Up,
+    Down,
+    Left,
+    Right,
+    Count,
+};
+
+struct ButtonState {
+    bool pressed = false;
+    bool held = false;
+    bool released = false;
+};
+
+struct Image {
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::vector<std::uint8_t> rgba;
+};
+
+struct Color {
+    std::uint8_t red = 255;
+    std::uint8_t green = 255;
+    std::uint8_t blue = 255;
+    std::uint8_t alpha = 255;
+};
+
+class Input {
+public:
+    bool initialize();
+    bool poll();
+    void shutdown();
+    const ButtonState& button(Button button) const;
+
+private:
+    void set_button(Button button, bool held);
+    void open_controller(int device_index);
+
+    std::array<ButtonState, static_cast<std::size_t>(Button::Count)> buttons_{};
+    void* controller_ = nullptr;
+    bool initialized_ = false;
+};
+
+using TextureId = std::uint32_t;
+
+class Graphics {
+public:
+    bool initialize();
+    bool available() const;
+    TextureId create_texture(const Image& image);
+    void destroy_texture(TextureId texture);
+    void begin_frame();
+    void draw_gradient(float x, float y, float width, float height,
+                       Color top_left, Color top_right,
+                       Color bottom_left, Color bottom_right);
+    void draw_image(TextureId texture, float x, float y, float width, float height,
+                    float opacity = 1.0f, float u_max = 1.0f, float v_max = 1.0f);
+    void draw_image_tinted(TextureId texture, float x, float y, float width, float height,
+                           Color tint, float u_max = 1.0f, float v_max = 1.0f);
+    void draw_image_rotated(TextureId texture, float center_x, float center_y,
+                            float width, float height, float rotation_degrees);
+    void draw_image_region(TextureId texture, float x, float y, float width, float height,
+                           float u0, float v0, float u1, float v1, Color tint = {});
+    void draw_image_repeated(TextureId texture, float x, float y, float width, float height,
+                             float u0, float v0, float u1, float v1, Color tint = {});
+    void draw_image_masked(TextureId texture, TextureId mask,
+                           float x, float y, float width, float height,
+                           float u0, float v0, float u1, float v1,
+                           float mask_u0, float mask_v0, float mask_u1, float mask_v1,
+                           Color tint = {});
+    void present();
+    void shutdown();
+
+private:
+    void* window_ = nullptr;
+    void* context_ = nullptr;
+    bool initialized_ = false;
+};
+
+struct Config {
+    std::filesystem::path data_root;
+    std::uint32_t update_hz = 60;
+    bool sleep_enabled = true;
+    bool graphics_enabled = true;
+};
+
+class FileSystem {
+public:
+    explicit FileSystem(std::filesystem::path root);
+
+    bool available() const;
+    const std::filesystem::path& root() const;
+    std::filesystem::path resolve(const std::filesystem::path& relative) const;
+    std::filesystem::path resolve_archive(std::uint32_t archive_id,
+                                          std::uint32_t data_id) const;
+    std::vector<std::uint8_t> read_binary(const std::filesystem::path& relative) const;
+
+private:
+    std::filesystem::path root_;
+};
+
+class Runtime {
+public:
+    bool initialize(const Config& config);
+    void poll_events();
+    bool quit_requested() const;
+    void request_quit();
+    void wait_for_next_frame();
+    void log(const std::string& message) const;
+    void shutdown();
+
+    const FileSystem& files() const;
+    const Input& input() const;
+    Graphics& graphics();
+
+private:
+    Config config_{};
+    FileSystem files_{"game-data"};
+    Input input_{};
+    Graphics graphics_{};
+    std::chrono::steady_clock::time_point next_frame_{};
+    bool initialized_ = false;
+    bool quit_requested_ = false;
+};
+
+} // namespace Platform
+
+#endif

--- a/pc/include/pokemoon/process_manager.hpp
+++ b/pc/include/pokemoon/process_manager.hpp
@@ -1,0 +1,83 @@
+#ifndef POKEMOON_PC_PROCESS_MANAGER_HPP
+#define POKEMOON_PC_PROCESS_MANAGER_HPP
+
+#include <memory>
+#include <string_view>
+
+namespace gfl2::proc {
+
+class Manager;
+
+enum class CallbackResult {
+    Continue = 0,
+    Finish = 1,
+};
+
+enum class ManagerResult {
+    Empty = 0,
+    Running = 1,
+    Transition = 2,
+    Pushed = 3,
+};
+
+enum class ProcessState {
+    Created = 0,
+    Initializing = 1,
+    Running = 2,
+    Ending = 3,
+    Complete = 4,
+};
+
+class BaseProcess {
+public:
+    virtual ~BaseProcess() = default;
+
+    virtual CallbackResult initialize(Manager& manager) = 0;
+    virtual CallbackResult update(Manager& manager) = 0;
+    virtual void draw(Manager& manager) = 0;
+    virtual CallbackResult end(Manager& manager) = 0;
+    virtual std::string_view name() const = 0;
+};
+
+class Manager {
+public:
+    Manager();
+    ~Manager();
+
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+
+    bool call_proc(std::unique_ptr<BaseProcess> process);
+    bool change_proc(std::unique_ptr<BaseProcess> process);
+    ManagerResult main();
+    void draw();
+    void request_end();
+
+    BaseProcess* current_process();
+    const BaseProcess* current_process() const;
+    bool current_process_initialized() const;
+    ProcessState current_state() const;
+    bool empty() const;
+
+private:
+    struct Node;
+    enum class PendingMode {
+        None,
+        Push,
+        Replace,
+    };
+
+    bool dispatch_current();
+    void install_pending(bool preserve_parent);
+    void remove_current();
+
+    std::unique_ptr<Node> current_;
+    std::unique_ptr<BaseProcess> pending_;
+    PendingMode pending_mode_ = PendingMode::None;
+    bool main_active_ = false;
+    bool end_requested_ = false;
+};
+
+} // namespace gfl2::proc
+
+#endif

--- a/pc/include/pokemoon/startup_language.hpp
+++ b/pc/include/pokemoon/startup_language.hpp
@@ -1,0 +1,23 @@
+#ifndef POKEMOON_PC_STARTUP_LANGUAGE_HPP
+#define POKEMOON_PC_STARTUP_LANGUAGE_HPP
+
+#include "pokemoon/platform.hpp"
+
+#include <cstdint>
+#include <optional>
+
+namespace PokemonMoon {
+
+struct StartupLanguageProfile {
+    std::uint8_t language = 0;
+    bool kanji_mode = false;
+};
+
+std::optional<StartupLanguageProfile> load_startup_language_profile(
+    const Platform::FileSystem& files);
+void save_startup_language_profile(const Platform::FileSystem& files,
+                                   StartupLanguageProfile profile);
+
+} // namespace PokemonMoon
+
+#endif

--- a/pc/include/pokemoon/title_resources.hpp
+++ b/pc/include/pokemoon/title_resources.hpp
@@ -1,0 +1,83 @@
+#ifndef POKEMOON_PC_TITLE_RESOURCES_HPP
+#define POKEMOON_PC_TITLE_RESOURCES_HPP
+
+#include "pokemoon/platform.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace PokemonMoon {
+
+enum class LayoutAnimationCurve : std::uint8_t {
+    Constant,
+    Step,
+    Hermite,
+};
+
+struct LayoutAnimationKey {
+    float frame = 0.0f;
+    float value = 0.0f;
+    float slope = 0.0f;
+};
+
+struct LayoutAnimationTrack {
+    std::string target;
+    std::string tag;
+    std::uint8_t component = 0;
+    std::uint8_t channel = 0;
+    LayoutAnimationCurve curve = LayoutAnimationCurve::Constant;
+    std::vector<LayoutAnimationKey> keys;
+};
+
+struct LayoutAnimation {
+    std::uint16_t frame_count = 0;
+    bool loop = false;
+    std::vector<LayoutAnimationTrack> tracks;
+};
+
+struct TitleMenuResources {
+    Platform::Image upper_background;
+    Platform::Image sea_pattern;
+    Platform::Image lower_pattern;
+    Platform::Image report_background;
+    Platform::Image cursor;
+    std::array<Platform::Image, 3> yellow_button;
+    std::array<Platform::Image, 3> red_button;
+};
+
+struct StartupLanguageResources {
+    Platform::Image upper_background;
+    Platform::Image sea_pattern;
+    Platform::Image sea_pattern_1;
+    Platform::Image sea_mask;
+    Platform::Image plate;
+    Platform::Image header_plate;
+    std::array<Platform::Image, 3> normal_button;
+    std::array<Platform::Image, 3> selected_button;
+    Platform::Image float_back;
+    Platform::Image float_front;
+    std::array<Platform::Image, 12> pikachu;
+    std::array<Platform::Image, 9> languages;
+    Platform::Image lower_pattern_0;
+    Platform::Image lower_pattern_1;
+    Platform::Image lower_window;
+    Platform::Image lower_window_fill;
+    Platform::Image selection_cursor;
+    LayoutAnimation character_idle;
+    LayoutAnimation upper_background_loop;
+    LayoutAnimation lower_background_loop;
+};
+
+TitleMenuResources decode_title_menu_resources(
+    const std::vector<std::uint8_t>& title_layout_archive,
+    const std::vector<std::uint8_t>& common_layout_archive);
+
+StartupLanguageResources decode_startup_language_resources(
+    const std::vector<std::uint8_t>& language_layout_archive,
+    const std::vector<std::uint8_t>& common_layout_archive = {});
+
+} // namespace PokemonMoon
+
+#endif

--- a/pc/src/application.cpp
+++ b/pc/src/application.cpp
@@ -1,0 +1,1100 @@
+#include "pokemoon/application.hpp"
+#include "pokemoon/frame_manager.hpp"
+#include "pokemoon/title_resources.hpp"
+#include "savedata/sodateya.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#ifdef PC_STARTUP_LANGUAGE
+#include <SDL_ttf.h>
+#endif
+
+namespace PokemonMoon {
+
+struct NativeTitleTextures {
+    Platform::TextureId upper_background = 0;
+    Platform::TextureId sea_pattern = 0;
+    Platform::TextureId lower_pattern = 0;
+    Platform::TextureId report_background = 0;
+    Platform::TextureId cursor = 0;
+    std::array<Platform::TextureId, 3> yellow_button{};
+    std::array<Platform::TextureId, 3> red_button{};
+};
+
+#ifdef PC_STARTUP_LANGUAGE
+struct NativeStartupLanguageTextures {
+    Platform::TextureId upper_background = 0;
+    Platform::TextureId sea_pattern = 0;
+    Platform::TextureId sea_pattern_1 = 0;
+    Platform::TextureId sea_mask = 0;
+    Platform::TextureId plate = 0;
+    Platform::TextureId header_plate = 0;
+    std::array<Platform::TextureId, 3> normal_button{};
+    std::array<Platform::TextureId, 3> selected_button{};
+    Platform::TextureId float_back = 0;
+    Platform::TextureId float_front = 0;
+    std::array<Platform::TextureId, 12> pikachu{};
+    std::array<Platform::TextureId, 9> languages{};
+    Platform::TextureId lower_pattern_0 = 0;
+    Platform::TextureId lower_pattern_1 = 0;
+    Platform::TextureId lower_window = 0;
+    Platform::TextureId lower_window_fill = 0;
+    Platform::TextureId selection_cursor = 0;
+    std::array<Platform::TextureId, 7> prompt{};
+};
+
+Platform::Image make_prompt_text(std::string_view text) {
+    if (TTF_WasInit() != 0 || TTF_Init() == 0) {
+        constexpr std::array<const char*, 2> font_paths{{
+            "/usr/share/fonts/noto/NotoSans-Regular.ttf",
+            "/usr/share/fonts/TTF/DejaVuSansCondensed.ttf",
+        }};
+        TTF_Font* font = nullptr;
+        for (const auto* path : font_paths) {
+            if (std::filesystem::is_regular_file(path)) {
+                font = TTF_OpenFont(path, 13);
+                if (font != nullptr) {
+                    break;
+                }
+            }
+        }
+        if (font != nullptr) {
+            const auto owned_text = std::string(text);
+            const SDL_Color white{255, 255, 255, 255};
+            auto* rendered = TTF_RenderUTF8_Blended(font, owned_text.c_str(), white);
+            TTF_CloseFont(font);
+            if (rendered != nullptr) {
+                auto* rgba = SDL_ConvertSurfaceFormat(rendered, SDL_PIXELFORMAT_RGBA32, 0);
+                SDL_FreeSurface(rendered);
+                if (rgba != nullptr) {
+                    Platform::Image image;
+                    image.width = static_cast<std::uint32_t>(rgba->w);
+                    image.height = static_cast<std::uint32_t>(rgba->h);
+                    image.rgba.resize(static_cast<std::size_t>(image.width) * image.height * 4);
+                    for (std::uint32_t row = 0; row < image.height; ++row) {
+                        const auto* source = static_cast<const std::uint8_t*>(rgba->pixels) +
+                            static_cast<std::size_t>(row) * static_cast<std::size_t>(rgba->pitch);
+                        std::copy_n(source, static_cast<std::size_t>(image.width) * 4,
+                                    image.rgba.begin() +
+                                        static_cast<std::ptrdiff_t>(row * image.width * 4));
+                    }
+                    SDL_FreeSurface(rgba);
+                    return image;
+                }
+            }
+        }
+    }
+    const auto glyph = [](char character) -> std::array<std::uint8_t, 7> {
+        switch (character >= 'a' && character <= 'z' ? character - 'a' + 'A' : character) {
+        case 'A': return {{0x0e, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11}};
+        case 'B': return {{0x1e, 0x11, 0x11, 0x1e, 0x11, 0x11, 0x1e}};
+        case 'C': return {{0x0e, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0e}};
+        case 'D': return {{0x1e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1e}};
+        case 'E': return {{0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x1f}};
+        case 'F': return {{0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x10}};
+        case 'G': return {{0x0e, 0x11, 0x10, 0x17, 0x11, 0x11, 0x0f}};
+        case 'H': return {{0x11, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11}};
+        case 'I': return {{0x0e, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0e}};
+        case 'K': return {{0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11}};
+        case 'L': return {{0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1f}};
+        case 'M': return {{0x11, 0x1b, 0x15, 0x15, 0x11, 0x11, 0x11}};
+        case 'N': return {{0x11, 0x19, 0x19, 0x15, 0x13, 0x13, 0x11}};
+        case 'O': return {{0x0e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e}};
+        case 'P': return {{0x1e, 0x11, 0x11, 0x1e, 0x10, 0x10, 0x10}};
+        case 'R': return {{0x1e, 0x11, 0x11, 0x1e, 0x14, 0x12, 0x11}};
+        case 'S': return {{0x0f, 0x10, 0x10, 0x0e, 0x01, 0x01, 0x1e}};
+        case 'T': return {{0x1f, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04}};
+        case 'U': return {{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e}};
+        case 'V': return {{0x11, 0x11, 0x11, 0x11, 0x11, 0x0a, 0x04}};
+        case 'W': return {{0x11, 0x11, 0x11, 0x15, 0x15, 0x1b, 0x11}};
+        case 'Y': return {{0x11, 0x11, 0x0a, 0x04, 0x04, 0x04, 0x04}};
+        case '+': return {{0, 0x04, 0x04, 0x1f, 0x04, 0x04, 0}};
+        case '\'': return {{0x0c, 0x08, 0x10, 0, 0, 0, 0}};
+        case '.': return {{0, 0, 0, 0, 0, 0x0c, 0x0c}};
+        case ',': return {{0, 0, 0, 0, 0, 0x0c, 0x08}};
+        default: return {};
+        }
+    };
+    Platform::Image image;
+    image.width = static_cast<std::uint32_t>(text.size() * 6);
+    image.height = 7;
+    image.rgba.resize(static_cast<std::size_t>(image.width) * image.height * 4);
+    for (std::size_t character = 0; character < text.size(); ++character) {
+        const auto rows = glyph(text[character]);
+        for (std::size_t y = 0; y < rows.size(); ++y) {
+            for (std::size_t x = 0; x < 5; ++x) {
+                if ((rows[y] & (1u << (4 - x))) == 0) {
+                    continue;
+                }
+                const auto offset = (y * image.width + character * 6 + x) * 4;
+                image.rgba[offset] = 0xff;
+                image.rgba[offset + 1] = 0xff;
+                image.rgba[offset + 2] = 0xff;
+                image.rgba[offset + 3] = 0xff;
+            }
+        }
+    }
+    return image;
+}
+#endif
+
+class Application::TitleMenuFrameCell final : public applib::frame::CellSuper {
+public:
+    TitleMenuFrameCell(Application& application, NativeTitleTextures textures)
+        : application_(application), textures_(textures) {}
+
+    applib::frame::CallbackResult initialize() override {
+        if (!initialization_started_) {
+            initialization_started_ = true;
+            return applib::frame::CallbackResult::Continue;
+        }
+        state_ = ControllerState::InputEnabled;
+        application_.platform_.log("TITLE_INPUT_ENABLED");
+        application_.platform_.log("TITLE_CONTROLLER_STATE=3");
+        return applib::frame::CallbackResult::AdvanceNextFrame;
+    }
+
+    applib::frame::CallbackResult update() override {
+        application_.run_native_frame();
+        application_.platform_.log("TITLE_FRAME=" + std::to_string(application_.frame_count()));
+
+        if (state_ == ControllerState::InputEnabled) {
+            const auto& input = application_.platform_.input();
+            if (input.button(Platform::Button::A).pressed) {
+                application_.platform_.log("TITLE_SELECTION_TRIGGER=0");
+                begin_exit();
+            } else if (input.button(Platform::Button::B).pressed) {
+                application_.platform_.log("TITLE_CANCEL_ACTION=4");
+                begin_exit();
+            }
+        } else if (state_ == ControllerState::ExitWait) {
+            state_ = ControllerState::NotifyCompletion;
+            application_.platform_.log("TITLE_CONTROLLER_STATE=5");
+        } else if (state_ == ControllerState::NotifyCompletion) {
+            state_ = ControllerState::Complete;
+            application_.platform_.log("TITLE_FRAME_COMPLETE_CALLBACK");
+            application_.platform_.log("TITLE_CONTROLLER_STATE=6");
+            return applib::frame::CallbackResult::AdvanceNextFrame;
+        }
+        return applib::frame::CallbackResult::Continue;
+    }
+
+    void draw(std::uint32_t) override {
+        auto& graphics = application_.platform_.graphics();
+        graphics.begin_frame();
+        constexpr Platform::Color sea_top_left{0x50, 0xdd, 0xea, 0xff};
+        constexpr Platform::Color sea_top_right{0x03, 0x96, 0xd1, 0xff};
+        constexpr Platform::Color sea_bottom_left{0x99, 0xff, 0xff, 0xff};
+        constexpr Platform::Color sea_bottom_right{0xb6, 0xec, 0xf1, 0xff};
+        constexpr Platform::Color lower_top_left{0x00, 0xdc, 0xd2, 0xff};
+        constexpr Platform::Color lower_top_right{0xc0, 0xff, 0xea, 0xff};
+        constexpr Platform::Color lower_bottom_left{0x24, 0x71, 0xde, 0xff};
+        constexpr Platform::Color lower_bottom_right{0x00, 0xd2, 0xdc, 0xff};
+        graphics.draw_gradient(0.0f, 0.0f, 400.0f, 240.0f,
+                               sea_top_left, sea_top_right,
+                               sea_bottom_left, sea_bottom_right);
+        graphics.draw_gradient(40.0f, 240.0f, 320.0f, 240.0f,
+                               lower_top_left, lower_top_right,
+                               lower_bottom_left, lower_bottom_right);
+        draw_sea_pattern(graphics, textures_.sea_pattern, 0.0f, 0.0f, 400.0f, 240.0f);
+        draw_tiled_pattern(graphics, textures_.lower_pattern,
+                           40.0f, 240.0f, 320.0f, 240.0f, 70.0f / 255.0f);
+        graphics.draw_image(textures_.upper_background, 0.0f, 0.0f, 400.0f, 128.0f);
+        if (textures_.report_background != 0) {
+            graphics.draw_image(textures_.report_background, 46.0f, 4.0f, 308.0f, 168.0f);
+        }
+        draw_button(graphics, textures_.yellow_button, 58.0f, 176.0f);
+        draw_button(graphics, textures_.red_button, 58.0f, 208.0f);
+        if (textures_.cursor != 0 && state_ == ControllerState::InputEnabled) {
+            graphics.draw_image(textures_.cursor, 50.0f, 76.0f, 16.0f, 16.0f);
+        }
+        graphics.present();
+        if (!draw_reached_) {
+            application_.platform_.log("TITLE_DRAW_REACHED");
+            draw_reached_ = true;
+        }
+    }
+
+    applib::frame::CallbackResult end() override {
+        if (!cleanup_started_) {
+            cleanup_started_ = true;
+            // TODO_PC_STUB: Retail title controller/resource teardown is pending reconstruction.
+            return applib::frame::CallbackResult::Continue;
+        }
+        return applib::frame::CallbackResult::AdvanceNextFrame;
+    }
+
+private:
+    enum class ControllerState : std::uint8_t {
+        InputEnabled = 3,
+        ExitWait = 4,
+        NotifyCompletion = 5,
+        Complete = 6,
+    };
+
+    void begin_exit() {
+        state_ = ControllerState::ExitWait;
+        application_.platform_.log("TITLE_CONTROLLER_STATE=4");
+    }
+
+    static void draw_button(Platform::Graphics& graphics,
+                            const std::array<Platform::TextureId, 3>& textures,
+                            float x,
+                            float y) {
+        graphics.draw_image(textures[0], x, y, 16.0f, 28.0f);
+        graphics.draw_image(textures[1], x + 16.0f, y, 252.0f, 28.0f);
+        graphics.draw_image(textures[2], x + 268.0f, y, 16.0f, 28.0f);
+    }
+
+    static void draw_sea_pattern(Platform::Graphics& graphics,
+                                 Platform::TextureId texture,
+                                 float x,
+                                 float y,
+                                 float width,
+                                 float height) {
+        for (float tile_y = y; tile_y < y + height; tile_y += 64.0f) {
+            for (float tile_x = x; tile_x < x + width; tile_x += 64.0f) {
+                const auto tile_width = std::min(64.0f, x + width - tile_x);
+                const auto tile_height = std::min(64.0f, y + height - tile_y);
+                graphics.draw_image(texture, tile_x, tile_y, tile_width, tile_height,
+                                    120.0f / 255.0f,
+                                    tile_width / 64.0f, tile_height / 64.0f);
+            }
+        }
+    }
+
+    static void draw_tiled_pattern(Platform::Graphics& graphics,
+                                   Platform::TextureId texture,
+                                   float x,
+                                   float y,
+                                   float width,
+                                   float height,
+                                   float opacity) {
+        for (float tile_y = y; tile_y < y + height; tile_y += 64.0f) {
+            for (float tile_x = x; tile_x < x + width; tile_x += 64.0f) {
+                const auto tile_width = std::min(64.0f, x + width - tile_x);
+                const auto tile_height = std::min(64.0f, y + height - tile_y);
+                graphics.draw_image(texture, tile_x, tile_y, tile_width, tile_height,
+                                    opacity, tile_width / 64.0f, tile_height / 64.0f);
+            }
+        }
+    }
+
+    Application& application_;
+    NativeTitleTextures textures_{};
+    ControllerState state_ = ControllerState::InputEnabled;
+    bool initialization_started_ = false;
+    bool draw_reached_ = false;
+    bool cleanup_started_ = false;
+};
+
+class Application::TitleMenuProcess final : public gfl2::proc::BaseProcess {
+public:
+    explicit TitleMenuProcess(Application& application) : application_(application) {}
+
+    gfl2::proc::CallbackResult initialize(gfl2::proc::Manager&) override {
+        if (!initialization_started_) {
+            application_.platform_.log("TITLE_INIT_ENTER");
+            application_.platform_.log("TITLE_RESOURCE_REQUEST=TitleMenu.cro");
+            constexpr std::array<std::pair<std::uint32_t, std::uint32_t>, 3> resources{{
+                {0x5e, 4},
+                {0x8a, 0},
+                {0x4a, 0},
+            }};
+            std::array<std::vector<std::uint8_t>, 3> resource_data;
+            for (std::size_t index = 0; index < resources.size(); ++index) {
+                const auto [archive_id, data_id] = resources[index];
+                const auto path = application_.platform_.files().resolve_archive(archive_id, data_id);
+                const auto relative = path.lexically_relative(application_.platform_.files().root());
+                const auto identity = relative.generic_string();
+                if (!std::filesystem::is_regular_file(path)) {
+                    application_.platform_.log("TITLE_RESOURCE_MISSING=" + identity);
+                    continue;
+                }
+                const auto data = application_.platform_.files().read_binary(relative);
+                application_.platform_.log("TITLE_RESOURCE_LOADED=" + identity +
+                                           ":" + std::to_string(data.size()));
+                resource_data[index] = data;
+            }
+            if (application_.platform_.graphics().available() &&
+                    !resource_data[1].empty() && !resource_data[2].empty()) {
+                try {
+                    const auto decoded = decode_title_menu_resources(resource_data[1], resource_data[2]);
+                    textures_.upper_background = application_.platform_.graphics().create_texture(
+                        decoded.upper_background);
+                    textures_.sea_pattern = application_.platform_.graphics().create_texture(
+                        decoded.sea_pattern);
+                    textures_.lower_pattern = application_.platform_.graphics().create_texture(
+                        decoded.lower_pattern);
+                    textures_.report_background = application_.platform_.graphics().create_texture(
+                        decoded.report_background);
+                    textures_.cursor = application_.platform_.graphics().create_texture(decoded.cursor);
+                    for (std::size_t index = 0; index < textures_.yellow_button.size(); ++index) {
+                        textures_.yellow_button[index] =
+                            application_.platform_.graphics().create_texture(decoded.yellow_button[index]);
+                        textures_.red_button[index] =
+                            application_.platform_.graphics().create_texture(decoded.red_button[index]);
+                    }
+                    application_.platform_.log(
+                        "TITLE_RETAIL_GRAPHICS_READY=upper_background,report,buttons,cursor");
+                } catch (const std::exception& error) {
+                    destroy_textures();
+                    application_.platform_.log(std::string("TITLE_RETAIL_GRAPHICS_FAILED=") + error.what());
+                }
+            }
+            initialization_started_ = true;
+            return gfl2::proc::CallbackResult::Continue;
+        }
+        if (!frame_manager_.call_proc(std::make_unique<TitleMenuFrameCell>(application_, textures_))) {
+            throw std::logic_error("title frame cell was already queued");
+        }
+        application_.platform_.log("TITLE_INIT_READY");
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    gfl2::proc::CallbackResult update(gfl2::proc::Manager&) override {
+        application_.platform_.log("TITLE_MAIN_ENTER");
+        if (frame_manager_.main() == applib::frame::ManagerResult::Empty) {
+            if (!transition_reported_) {
+                application_.platform_.log("TITLE_TRANSITION_COMPLETE");
+                application_.platform_.request_quit();
+                transition_reported_ = true;
+            }
+        }
+        return gfl2::proc::CallbackResult::Continue;
+    }
+
+    void draw(gfl2::proc::Manager&) override {
+        frame_manager_.draw(0);
+    }
+
+    gfl2::proc::CallbackResult end(gfl2::proc::Manager&) override {
+        if (frame_manager_.end()) {
+            return gfl2::proc::CallbackResult::Continue;
+        }
+        destroy_textures();
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    std::string_view name() const override {
+        return "TitleMenuProcess";
+    }
+
+private:
+    void destroy_textures() {
+        auto& graphics = application_.platform_.graphics();
+        graphics.destroy_texture(textures_.cursor);
+        graphics.destroy_texture(textures_.report_background);
+        graphics.destroy_texture(textures_.upper_background);
+        graphics.destroy_texture(textures_.sea_pattern);
+        graphics.destroy_texture(textures_.lower_pattern);
+        for (const auto texture : textures_.yellow_button) {
+            graphics.destroy_texture(texture);
+        }
+        for (const auto texture : textures_.red_button) {
+            graphics.destroy_texture(texture);
+        }
+        textures_ = {};
+    }
+
+    Application& application_;
+    applib::frame::Manager frame_manager_;
+    bool initialization_started_ = false;
+    bool transition_reported_ = false;
+    NativeTitleTextures textures_{};
+};
+
+#ifdef PC_STARTUP_LANGUAGE
+class Application::StartupLanguageProcess final : public gfl2::proc::BaseProcess {
+public:
+    explicit StartupLanguageProcess(Application& application) : application_(application) {}
+
+    gfl2::proc::CallbackResult initialize(gfl2::proc::Manager&) override {
+        if (!initialization_started_) {
+            application_.platform_.log("LANGUAGE_INIT_ENTER");
+            application_.platform_.log("LANGUAGE_RESOURCE_REQUEST=LangSelect.cro");
+            constexpr std::array<std::pair<std::uint32_t, std::uint32_t>, 2> resources{{
+                {0x8f, 0}, {0x4a, 0},
+            }};
+            std::array<std::vector<std::uint8_t>, 2> resource_data;
+            for (std::size_t index = 0; index < resources.size(); ++index) {
+                const auto [archive_id, data_id] = resources[index];
+                const auto path = application_.platform_.files().resolve_archive(archive_id, data_id);
+                const auto relative = path.lexically_relative(application_.platform_.files().root());
+                if (!std::filesystem::is_regular_file(path)) {
+                    application_.platform_.log("LANGUAGE_RESOURCE_MISSING=" + relative.generic_string());
+                    continue;
+                }
+                resource_data[index] = application_.platform_.files().read_binary(relative);
+                application_.platform_.log("LANGUAGE_RESOURCE_LOADED=" + relative.generic_string() +
+                                           ":" + std::to_string(resource_data[index].size()));
+            }
+            if (!resource_data[0].empty()) {
+                try {
+                    if (application_.platform_.graphics().available()) {
+                        const auto decoded = decode_startup_language_resources(
+                            resource_data[0], resource_data[1]);
+                        auto& graphics = application_.platform_.graphics();
+                        textures_.upper_background = graphics.create_texture(decoded.upper_background);
+                        textures_.sea_pattern = graphics.create_texture(decoded.sea_pattern);
+                        textures_.sea_pattern_1 = graphics.create_texture(decoded.sea_pattern_1);
+                        textures_.sea_mask = graphics.create_texture(decoded.sea_mask);
+                        textures_.plate = graphics.create_texture(decoded.plate);
+                        textures_.header_plate = graphics.create_texture(decoded.header_plate);
+                        textures_.float_back = graphics.create_texture(decoded.float_back);
+                        textures_.float_front = graphics.create_texture(decoded.float_front);
+                        for (std::size_t index = 0; index < textures_.normal_button.size(); ++index) {
+                            textures_.normal_button[index] =
+                                graphics.create_texture(decoded.normal_button[index]);
+                            textures_.selected_button[index] =
+                                graphics.create_texture(decoded.selected_button[index]);
+                        }
+                        for (std::size_t index = 0; index < textures_.pikachu.size(); ++index) {
+                            textures_.pikachu[index] = graphics.create_texture(decoded.pikachu[index]);
+                        }
+                        for (std::size_t index = 0; index < textures_.languages.size(); ++index) {
+                            textures_.languages[index] = graphics.create_texture(decoded.languages[index]);
+                        }
+                        textures_.lower_pattern_0 = graphics.create_texture(decoded.lower_pattern_0);
+                        textures_.lower_pattern_1 = graphics.create_texture(decoded.lower_pattern_1);
+                        textures_.lower_window = graphics.create_texture(decoded.lower_window);
+                        textures_.lower_window_fill = graphics.create_texture(decoded.lower_window_fill);
+                        textures_.selection_cursor = graphics.create_texture(decoded.selection_cursor);
+                        character_animation_ = decoded.character_idle;
+                        upper_background_animation_ = decoded.upper_background_loop;
+                        lower_background_animation_ = decoded.lower_background_loop;
+                        constexpr std::array<std::string_view, 7> prompt{{
+                            "Play the game in",
+                            "Use the +Control Pad to select a language.",
+                            "Press the A Button to confirm.",
+                            "Once your language has been set, you cannot",
+                            "change it during the game.",
+                            "If you aren't sure what to do, ask for",
+                            "help setting the language.",
+                        }};
+                        for (std::size_t index = 0; index < prompt.size(); ++index) {
+                            textures_.prompt[index] = graphics.create_texture(
+                                make_prompt_text(prompt[index]));
+                        }
+                        application_.platform_.log(
+                            "LANGUAGE_RETAIL_GRAPHICS_READY=layouts,animations,background,plate,"
+                            "pikachu,buttons,languages,lower_window");
+                    }
+                } catch (const std::exception& error) {
+                    destroy_textures();
+                    application_.platform_.log(std::string("LANGUAGE_RETAIL_GRAPHICS_FAILED=") +
+                                               error.what());
+                }
+            }
+            initialization_started_ = true;
+            return gfl2::proc::CallbackResult::Continue;
+        }
+        application_.platform_.log("LANGUAGE_INIT_READY");
+        application_.platform_.log("LANGUAGE_SELECTION=1");
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    gfl2::proc::CallbackResult update(gfl2::proc::Manager& manager) override {
+        application_.run_native_frame();
+        animation_frame_ += 0.5f;
+        if (animation_frame_ >= 600.0f) {
+            animation_frame_ -= 600.0f;
+        }
+        const auto& input = application_.platform_.input();
+        if (state_ == State::Select) {
+            if (input.button(Platform::Button::Up).pressed) {
+                selection_ = static_cast<std::uint8_t>((selection_ + 8) % 9);
+                report_selection();
+            } else if (input.button(Platform::Button::Down).pressed) {
+                selection_ = static_cast<std::uint8_t>((selection_ + 1) % 9);
+                report_selection();
+            } else if (input.button(Platform::Button::A).pressed) {
+                state_ = State::Confirm;
+                confirmation_guard_ = 15;
+                application_.platform_.log("LANGUAGE_CONFIRM_ENTER=" +
+                                           std::to_string(selection_));
+            }
+            return gfl2::proc::CallbackResult::Continue;
+        }
+
+        if (state_ == State::Confirm) {
+            if (confirmation_guard_ != 0) {
+                --confirmation_guard_;
+                return gfl2::proc::CallbackResult::Continue;
+            }
+            if (input.button(Platform::Button::B).pressed) {
+                state_ = State::Select;
+                application_.platform_.log("LANGUAGE_CONFIRM_CANCEL");
+            } else if (selection_ == 0 &&
+                       (input.button(Platform::Button::Left).pressed ||
+                        input.button(Platform::Button::Right).pressed)) {
+                kanji_mode_ = !kanji_mode_;
+                application_.platform_.log(std::string("LANGUAGE_KANJI_MODE=") +
+                                           (kanji_mode_ ? "1" : "0"));
+            } else if (input.button(Platform::Button::A).pressed) {
+                const StartupLanguageProfile profile{selection_, kanji_mode_};
+                save_startup_language_profile(application_.platform_.files(), profile);
+                application_.apply_startup_language_profile(profile);
+                application_.platform_.log("LANGUAGE_PROFILE_COMMITTED");
+                application_.platform_.log("TITLE_PROCESS_SELECTED");
+                if (!manager.change_proc(std::make_unique<TitleMenuProcess>(application_))) {
+                    throw std::logic_error("title process was already queued");
+                }
+                state_ = State::Handoff;
+                application_.platform_.log("LANGUAGE_HANDOFF_QUEUED");
+                return gfl2::proc::CallbackResult::Finish;
+            }
+        }
+        return gfl2::proc::CallbackResult::Continue;
+    }
+
+    void draw(gfl2::proc::Manager&) override {
+        auto& graphics = application_.platform_.graphics();
+        graphics.begin_frame();
+        constexpr Platform::Color upper_left{0x51, 0xe2, 0xef, 0xff};
+        constexpr Platform::Color upper_right{0x05, 0x9b, 0xd4, 0xff};
+        constexpr Platform::Color lower_left{0x00, 0xdc, 0xd2, 0xff};
+        constexpr Platform::Color lower_right{0x16, 0x7d, 0xe8, 0xff};
+        graphics.draw_gradient(0.0f, 0.0f, 400.0f, 240.0f,
+                               upper_left, upper_right, upper_left, upper_right);
+        graphics.draw_gradient(40.0f, 240.0f, 320.0f, 240.0f,
+                               lower_left, lower_right, lower_left, lower_right);
+        if (textures_.upper_background != 0) {
+            graphics.draw_image(textures_.upper_background, 0.0f, 0.0f, 400.0f, 128.0f);
+        }
+        const auto frame = animation_frame_;
+        const auto sea_scroll_0 = evaluate_track(
+            upper_background_animation_, "Sea_00", "FLTS", 0, 0, frame, 0.0f);
+        const auto sea_scroll_1 = evaluate_track(
+            upper_background_animation_, "Sea_00", "FLTS", 1, 0, frame, 0.0f);
+        const auto mask_u = evaluate_track(
+            upper_background_animation_, "Sea_00", "FLTS", 2, 0, frame, 0.0f);
+        const auto mask_v = evaluate_track(
+            upper_background_animation_, "Sea_00", "FLTS", 2, 1, frame, 0.28f);
+        const auto mask_v_offset = -0.14f + (mask_v - 0.28f) * 0.2f;
+        graphics.draw_image_masked(textures_.sea_pattern, textures_.sea_mask,
+            0.0f, 12.0f, 400.0f, 228.0f,
+            sea_scroll_0, 0.0f, sea_scroll_0 + 4.0f, 4.0f,
+            mask_u, mask_v_offset, mask_u + 1.0f, mask_v_offset + 1.0f);
+        graphics.draw_image_masked(textures_.sea_pattern, textures_.sea_mask,
+            0.0f, 12.0f, 400.0f, 228.0f,
+            sea_scroll_1, 0.0f, sea_scroll_1 - 3.0f, -3.0f,
+            mask_u, mask_v_offset, mask_u + 1.0f, mask_v_offset + 1.0f,
+            {255, 255, 255, 96});
+        const auto foam_u = evaluate_track(
+            upper_background_animation_, "Sea_01", "FLTS", 0, 0, frame, 0.0f);
+        const auto foam_v = evaluate_track(
+            upper_background_animation_, "Sea_01", "FLTS", 0, 1, frame, 0.28f);
+        const auto foam_v_offset = -0.14f + (foam_v - 0.28f) * 0.2f;
+        graphics.draw_image_repeated(textures_.sea_pattern_1, 0.0f, 12.0f, 400.0f, 228.0f,
+                                     foam_u, foam_v_offset,
+                                     foam_u + 1.0f, foam_v_offset + 1.0f,
+                                     {255, 255, 255, 210});
+        const auto lower_u_1 = evaluate_track(
+            lower_background_animation_, "bg_ptn_01", "FLTS", 0, 0, frame, 0.0f);
+        const auto lower_v_1 = evaluate_track(
+            lower_background_animation_, "bg_ptn_01", "FLTS", 0, 1, frame, 0.0f);
+        const auto lower_u_2 = evaluate_track(
+            lower_background_animation_, "bg_ptn_02", "FLTS", 0, 0, frame, 0.0f);
+        const auto lower_v_2 = evaluate_track(
+            lower_background_animation_, "bg_ptn_02", "FLTS", 0, 1, frame, 0.0f);
+        const auto lower_alpha = evaluate_track(
+            lower_background_animation_, "bg_ptn_01", "FLVC", 0, 16,
+            frame, 70.0f) / 255.0f;
+        graphics.draw_image_repeated(textures_.lower_pattern_0, 40.0f, 240.0f, 320.0f, 240.0f,
+                                     5.0f, -15.0f, 45.0f, 15.0f,
+                                     {250, 250, 250, 255});
+        graphics.draw_image_repeated(textures_.lower_pattern_1, 40.0f, 240.0f, 320.0f, 240.0f,
+                                     lower_u_1 + 0.5f, lower_v_1 - 15.0f,
+                                     lower_u_1 + 4.5f, lower_v_1 - 12.0f,
+                                     {255, 255, 255, static_cast<std::uint8_t>(lower_alpha * 255.0f)});
+        graphics.draw_image_repeated(textures_.lower_pattern_1, 40.0f, 240.0f, 320.0f, 240.0f,
+                                     lower_u_2 + 0.5f, lower_v_2 - 15.0f,
+                                     lower_u_2 + 4.5f, lower_v_2 - 12.0f,
+                                     {255, 255, 255, 100});
+        draw_pikachu(graphics);
+        graphics.draw_image(textures_.plate, 0.0f, 93.0f, 400.0f, 72.0f);
+        graphics.draw_image(textures_.header_plate, 40.0f, 105.0f, 320.0f, 24.0f);
+        draw_centered_text(graphics, textures_.prompt[0], 200.0f, 106.0f, 1.5f, 2.0f);
+        if (state_ == State::Select) {
+            const auto first = std::min<std::size_t>(
+                selection_ == 0 ? 0 : selection_ > 4 ? selection_ - 3 : 1,
+                textures_.languages.size() - 4);
+            for (std::size_t row = 0; row < 4; ++row) {
+                const auto display_index = first + row;
+                draw_language_button(graphics, display_index, row,
+                                     display_index == selection_);
+            }
+            draw_prompt_panel(graphics, textures_.lower_window,
+                              textures_.lower_window_fill, textures_.prompt);
+        } else {
+            draw_language_button(graphics, selection_, 0, true);
+            constexpr Platform::Color confirmation{0x09, 0x6b, 0x78, 0xff};
+            graphics.draw_gradient(60.0f, 292.0f, 280.0f, 112.0f,
+                                   confirmation, confirmation, confirmation, confirmation);
+            graphics.draw_image(textures_.languages[selection_],
+                                55.0f, 335.0f, 290.0f, 18.0f);
+        }
+        graphics.present();
+        if (!draw_reached_) {
+            application_.platform_.log("LANGUAGE_DRAW_REACHED");
+            draw_reached_ = true;
+        }
+    }
+
+    gfl2::proc::CallbackResult end(gfl2::proc::Manager&) override {
+        destroy_textures();
+        application_.platform_.log("LANGUAGE_END_COMPLETE");
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    std::string_view name() const override {
+        return "StartupLanguageProcess";
+    }
+
+private:
+    enum class State : std::uint8_t {
+        Select,
+        Confirm,
+        Handoff,
+    };
+
+    struct PanePose {
+        float x;
+        float y;
+        float rotation;
+    };
+
+    static float evaluate_track(const LayoutAnimation& animation,
+                                std::string_view target,
+                                std::string_view tag,
+                                std::uint8_t component,
+                                std::uint8_t channel,
+                                float frame,
+                                float fallback) {
+        const auto found = std::find_if(animation.tracks.begin(), animation.tracks.end(),
+            [&](const LayoutAnimationTrack& track) {
+                return track.target == target && track.tag == tag &&
+                       track.component == component && track.channel == channel;
+            });
+        if (found == animation.tracks.end() || found->keys.empty()) {
+            return fallback;
+        }
+        const auto& keys = found->keys;
+        if (found->curve == LayoutAnimationCurve::Constant || frame <= keys.front().frame) {
+            return keys.front().value;
+        }
+        if (found->curve == LayoutAnimationCurve::Step) {
+            auto value = keys.front().value;
+            for (const auto& key : keys) {
+                if (key.frame > frame) {
+                    break;
+                }
+                value = key.value;
+            }
+            return value;
+        }
+        for (std::size_t index = 1; index < keys.size(); ++index) {
+            if (frame > keys[index].frame) {
+                continue;
+            }
+            const auto& first = keys[index - 1];
+            const auto& second = keys[index];
+            const auto duration = second.frame - first.frame;
+            if (duration <= 0.0f) {
+                return second.value;
+            }
+            const auto time = (frame - first.frame) / duration;
+            const auto time2 = time * time;
+            const auto time3 = time2 * time;
+            return (2.0f * time3 - 3.0f * time2 + 1.0f) * first.value +
+                   (time3 - 2.0f * time2 + time) * duration * first.slope +
+                   (-2.0f * time3 + 3.0f * time2) * second.value +
+                   (time3 - time2) * duration * second.slope;
+        }
+        return keys.back().value;
+    }
+
+    static PanePose child_pose(const PanePose& parent, float x, float y, float rotation = 0.0f) {
+        constexpr float radians = 3.14159265358979323846f / 180.0f;
+        const auto angle = parent.rotation * radians;
+        const auto sine = std::sin(angle);
+        const auto cosine = std::cos(angle);
+        return {
+            parent.x + x * cosine - y * sine,
+            parent.y + x * sine + y * cosine,
+            parent.rotation + rotation,
+        };
+    }
+
+    static void draw_pane(Platform::Graphics& graphics, Platform::TextureId texture,
+                          const PanePose& pose, float width, float height,
+                          std::uint8_t position = 0) {
+        const auto horizontal = position & 3;
+        const auto vertical = (position >> 2) & 3;
+        const auto center_x = horizontal == 1 ? width / 2.0f :
+                              horizontal == 2 ? -width / 2.0f : 0.0f;
+        const auto center_y = vertical == 1 ? -height / 2.0f :
+                              vertical == 2 ? height / 2.0f : 0.0f;
+        const auto center = child_pose(pose, center_x, center_y);
+        graphics.draw_image_rotated(texture, center.x, 120.0f - center.y,
+                                    width, height, center.rotation);
+    }
+
+    void draw_pikachu(Platform::Graphics& graphics) const {
+        const auto frame = animation_frame_;
+        const PanePose character{
+            200.0f + evaluate_track(character_animation_, "Chara", "FLPA", 0, 0,
+                                    frame, 130.0f),
+            evaluate_track(character_animation_, "Chara", "FLPA", 0, 1,
+                           frame, 43.0f),
+            evaluate_track(character_animation_, "Chara", "FLPA", 0, 5,
+                           frame, 0.0f),
+        };
+        const auto float_back = child_pose(character, 8.0f, 9.0f);
+        const auto pika = child_pose(float_back, -8.0f, 22.0f);
+        draw_pane(graphics, textures_.float_back, float_back, 128.0f, 64.0f);
+
+        const auto tail_rotation = evaluate_track(
+            character_animation_, "pika_Tail", "FLPA", 0, 5, frame, -5.0f);
+        draw_pane(graphics, textures_.pikachu[0],
+                  child_pose(pika, 2.951f, -17.0f, tail_rotation), 64.0f, 96.0f, 10);
+        draw_pane(graphics, textures_.pikachu[1], child_pose(pika, 8.0f, -11.0f),
+                  64.0f, 64.0f);
+
+        const auto head = child_pose(pika, 3.0f, -14.0f, -7.976f);
+        const auto right_ear_rotation = evaluate_track(
+            character_animation_, "pika_R_Ear", "FLPA", 0, 5, frame, 5.0f);
+        const auto left_ear_rotation = evaluate_track(
+            character_animation_, "pika_L_Ear", "FLPA", 0, 5, frame, -1.5625f);
+        draw_pane(graphics, textures_.pikachu[7],
+                  child_pose(head, 27.0f, 31.0f, right_ear_rotation), 32.0f, 64.0f, 10);
+        draw_pane(graphics, textures_.pikachu[6], head, 64.0f, 64.0f, 9);
+        const auto eye = static_cast<std::size_t>(std::clamp(
+            evaluate_track(character_animation_, "pika_Eye", "FLTP", 0, 0,
+                           frame, 0.0f), 0.0f, 2.0f));
+        draw_pane(graphics, textures_.pikachu[9 + eye],
+                  child_pose(head, 23.0f, 28.0f), 32.0f, 32.0f);
+        draw_pane(graphics, textures_.pikachu[8],
+                  child_pose(head, 35.0f, 22.0f, left_ear_rotation), 32.0f, 64.0f, 9);
+
+        draw_pane(graphics, textures_.pikachu[5],
+                  child_pose(pika,
+                      evaluate_track(character_animation_, "pika_LP", "FLPA", 0, 0,
+                                     frame, 0.0f) + 22.0f,
+                      evaluate_track(character_animation_, "pika_LP", "FLPA", 0, 1,
+                                     frame, 0.0f) - 6.0f,
+                      evaluate_track(character_animation_, "pika_LP", "FLPA", 0, 5,
+                                     frame, 0.0f)), 32.0f, 32.0f);
+        draw_pane(graphics, textures_.pikachu[4],
+                  child_pose(pika,
+                      evaluate_track(character_animation_, "pika_RP", "FLPA", 0, 0,
+                                     frame, 0.0f) + 6.0f,
+                      evaluate_track(character_animation_, "pika_RP", "FLPA", 0, 1,
+                                     frame, 0.0f) + 5.0f,
+                      evaluate_track(character_animation_, "pika_RP", "FLPA", 0, 5,
+                                     frame, 0.0f)), 32.0f, 32.0f);
+        draw_pane(graphics, textures_.pikachu[2],
+                  child_pose(pika, 0.0f, -13.0f, evaluate_track(
+                      character_animation_, "pika_RK", "FLPA", 0, 5, frame, 9.03f)),
+                  32.0f, 32.0f, 10);
+        draw_pane(graphics, textures_.pikachu[3],
+                  child_pose(pika, -1.86f, -8.916f, evaluate_track(
+                      character_animation_, "pika_LK", "FLPA", 0, 5, frame, 1.608f)),
+                  32.0f, 32.0f);
+        draw_pane(graphics, textures_.float_front, child_pose(float_back, 0.0f, -4.0f),
+                  128.0f, 48.0f);
+    }
+
+    void draw_language_button(Platform::Graphics& graphics,
+                              std::size_t display_index,
+                              std::size_t row,
+                              bool selected) const {
+        const auto& button = selected ? textures_.selected_button : textures_.normal_button;
+        constexpr std::array<Platform::Color, 9> row_tints{{
+            {0xf0, 0x2f, 0x15, 0xff}, {0xff, 0x88, 0x00, 0xff},
+            {0xff, 0xbb, 0x00, 0xff}, {0x7b, 0xc0, 0x1b, 0xff},
+            {0x3f, 0x9f, 0x40, 0xff}, {0x1c, 0xae, 0x94, 0xff},
+            {0x28, 0x7d, 0xdc, 0xff}, {0x7f, 0x5f, 0xff, 0xff},
+            {0xf1, 0x4b, 0xe6, 0xff},
+        }};
+        const auto absolute_row = display_index;
+        const auto center_x = 202.0f + static_cast<float>(row) * 20.0f;
+        const auto y = 127.0f + static_cast<float>(row) * 30.0f;
+        const auto tint = selected ? Platform::Color{0xff, 0x9d, 0x9d, 0xff}
+                                   : row_tints[absolute_row % row_tints.size()];
+        const auto x = center_x - 333.3334f / 2.0f;
+        graphics.draw_image_tinted(button[0], x, y + 5.0f, 16.0f, 28.0f, tint);
+        graphics.draw_image_tinted(button[1], x + 16.0f, y + 5.0f, 301.3334f, 28.0f, tint);
+        graphics.draw_image_tinted(button[2], x + 317.3334f, y + 5.0f, 16.0f, 28.0f, tint);
+        graphics.draw_image(textures_.languages[display_index],
+                            center_x - 145.0f, y + 10.0f, 290.0f, 18.0f);
+        if (selected) {
+            constexpr float pi = 3.14159265358979323846f;
+            const auto cursor_offset = 2.0f - 2.0f *
+                std::cos(std::fmod(animation_frame_, 20.0f) * pi / 10.0f);
+            graphics.draw_image_rotated(textures_.selection_cursor,
+                                        x + cursor_offset, y + 19.0f,
+                                        20.0f, 20.0f, -90.0f);
+        }
+    }
+
+    static void draw_window_frame(Platform::Graphics& graphics,
+                                  Platform::TextureId texture,
+                                  float x,
+                                  float y,
+                                  float width,
+                                  float height) {
+        constexpr float corner = 14.0f;
+        constexpr Platform::Color cyan{0x18, 0xc5, 0xd1, 0xff};
+        constexpr Platform::Color navy{0x0b, 0x23, 0x32, 0xff};
+        constexpr Platform::Color gold{0x9e, 0x7b, 0x38, 0xff};
+        graphics.draw_gradient(x, y, width, height, cyan, cyan, cyan, cyan);
+        graphics.draw_gradient(x + 1.0f, y + 1.0f, width - 2.0f, height - 2.0f,
+                               navy, navy, navy, navy);
+        graphics.draw_gradient(x + 3.0f, y + 3.0f, width - 6.0f, height - 6.0f,
+                               gold, gold, gold, gold);
+        graphics.draw_image_region(texture, x, y, corner, corner, 0.0f, 0.0f, 1.0f, 1.0f);
+        graphics.draw_image_region(texture, x + width - corner, y, corner, corner,
+                                   1.0f, 0.0f, 0.0f, 1.0f);
+        graphics.draw_image_region(texture, x, y + height - corner, corner, corner,
+                                   0.0f, 1.0f, 1.0f, 0.0f);
+        graphics.draw_image_region(texture, x + width - corner, y + height - corner,
+                                   corner, corner, 1.0f, 1.0f, 0.0f, 0.0f);
+    }
+
+    static void draw_prompt_panel(Platform::Graphics& graphics,
+                                  Platform::TextureId window,
+                                  Platform::TextureId window_fill,
+                                  const std::array<Platform::TextureId, 7>& prompt) {
+        draw_window_frame(graphics, window, 44.0f, 244.0f, 312.0f, 232.0f);
+        graphics.draw_image(window_fill, 49.0f, 249.0f, 302.0f, 222.0f);
+        constexpr std::array<float, 6> y{{255.0f, 273.0f, 313.0f, 333.0f, 374.0f, 394.0f}};
+        constexpr std::array<float, 6> widths{{283.8f, 204.6f, 290.4f, 184.8f, 264.0f, 184.8f}};
+        for (std::size_t index = 0; index < y.size(); ++index) {
+            const Platform::Color tint = index == 2 || index == 3
+                ? Platform::Color{0xff, 0x22, 0x18, 0xff}
+                : Platform::Color{0xff, 0xff, 0xff, 0xff};
+            graphics.draw_image_tinted(prompt[index + 1], 55.0f, y[index],
+                                       widths[index], 14.0f, tint);
+        }
+    }
+
+    static void draw_centered_text(Platform::Graphics& graphics, Platform::TextureId texture,
+                                   float center_x, float y, float scale_x, float scale_y) {
+        constexpr float source_width = 16.0f * 6.0f;
+        graphics.draw_image(texture, center_x - source_width * scale_x / 2.0f, y,
+                            source_width * scale_x, 7.0f * scale_y);
+    }
+
+    void report_selection() const {
+        application_.platform_.log("LANGUAGE_SELECTION=" + std::to_string(selection_));
+    }
+
+    static void draw_tiled_pattern(Platform::Graphics& graphics,
+                                   Platform::TextureId texture,
+                                   float x,
+                                   float y,
+                                   float width,
+                                   float height,
+                                   float scroll_x,
+                                   float opacity) {
+        if (texture == 0) {
+            return;
+        }
+        const auto offset = std::fmod(scroll_x, 64.0f);
+        for (float tile_y = y; tile_y < y + height; tile_y += 64.0f) {
+            for (float tile_x = x - offset; tile_x < x + width; tile_x += 64.0f) {
+                const auto visible_x = std::max(x, tile_x);
+                const auto tile_width = std::min(tile_x + 64.0f, x + width) - visible_x;
+                const auto tile_height = std::min(64.0f, y + height - tile_y);
+                graphics.draw_image_region(texture, visible_x, tile_y, tile_width, tile_height,
+                    (visible_x - tile_x) / 64.0f, 0.0f,
+                    (visible_x + tile_width - tile_x) / 64.0f, tile_height / 64.0f,
+                    {255, 255, 255, static_cast<std::uint8_t>(
+                        std::clamp(opacity, 0.0f, 1.0f) * 255.0f)});
+            }
+        }
+    }
+
+    void destroy_textures() {
+        auto& graphics = application_.platform_.graphics();
+        graphics.destroy_texture(textures_.upper_background);
+        graphics.destroy_texture(textures_.sea_pattern);
+        graphics.destroy_texture(textures_.sea_pattern_1);
+        graphics.destroy_texture(textures_.sea_mask);
+        graphics.destroy_texture(textures_.plate);
+        graphics.destroy_texture(textures_.header_plate);
+        graphics.destroy_texture(textures_.float_back);
+        graphics.destroy_texture(textures_.float_front);
+        for (const auto texture : textures_.normal_button) {
+            graphics.destroy_texture(texture);
+        }
+        for (const auto texture : textures_.selected_button) {
+            graphics.destroy_texture(texture);
+        }
+        for (const auto texture : textures_.pikachu) {
+            graphics.destroy_texture(texture);
+        }
+        for (const auto texture : textures_.languages) {
+            graphics.destroy_texture(texture);
+        }
+        for (const auto texture : textures_.prompt) {
+            graphics.destroy_texture(texture);
+        }
+        graphics.destroy_texture(textures_.lower_pattern_0);
+        graphics.destroy_texture(textures_.lower_pattern_1);
+        graphics.destroy_texture(textures_.lower_window);
+        graphics.destroy_texture(textures_.lower_window_fill);
+        graphics.destroy_texture(textures_.selection_cursor);
+        textures_ = {};
+    }
+
+    Application& application_;
+    NativeStartupLanguageTextures textures_{};
+    LayoutAnimation character_animation_{};
+    LayoutAnimation upper_background_animation_{};
+    LayoutAnimation lower_background_animation_{};
+    State state_ = State::Select;
+    std::uint8_t selection_ = 1;
+    std::uint8_t confirmation_guard_ = 0;
+    float animation_frame_ = 0.0f;
+    bool kanji_mode_ = false;
+    bool initialization_started_ = false;
+    bool draw_reached_ = false;
+};
+#endif
+
+Application::Application(Platform::Runtime& platform) : platform_(platform) {}
+
+bool Application::initialize() {
+    startup_point_ = StartupPoint::PlatformReady;
+
+    gfl2::math::Random::State state{{0x12345678u, 0x9abcdef0u, 0x13579bdfu, 0x2468ace0u}};
+    random_.Initialize(state);
+    const auto first_random = random_.Next();
+    if (first_random == 0 || random_.SaveState().status[0] == state.status[0]) {
+        platform_.log("reconstructed TinyMT initialization self-check failed");
+        return false;
+    }
+
+    situation_.SetLastZoneID(1);
+    situation_.SetEggStepCount(0);
+    situation_.SetFriendlyStepCount(0);
+    situation_.SetKawaigariStepCount(0);
+    if (situation_.GetLastZoneID() != 1 || situation_.GetEggStepCount() != 0) {
+        platform_.log("reconstructed Situation accessors self-check failed");
+        return false;
+    }
+
+    box_.SetWallPaper(0, 7);
+    box_.SetTeamLock(0, true);
+    if (box_.GetWallPaper(0) != 7 || !box_.IsTeamLock(0)) {
+        platform_.log("reconstructed BOX accessors self-check failed");
+        return false;
+    }
+
+    Savedata::Sodateya daycare{};
+    const auto daycare_id = static_cast<Savedata::SodateyaID>(0);
+    daycare.EggClear(daycare_id);
+    if (daycare.IsEggExist(daycare_id) != 0) {
+        platform_.log("reconstructed daycare clear self-check failed");
+        return false;
+    }
+
+    startup_point_ = StartupPoint::ReconstructedCoreReady;
+    platform_.log("reconstructed initialization ready: TinyMT, Situation, BOX, and daycare");
+
+    game_manager_ = std::make_unique<GameSys::GameManager>();
+    if (GameSys::GameManager::instance() != game_manager_.get()) {
+        platform_.log("reconstructed GameManager singleton self-check failed");
+        return false;
+    }
+    startup_point_ = StartupPoint::GameManagerReady;
+    platform_.log("reconstructed GameManager lifecycle ready");
+
+    std::unique_ptr<gfl2::proc::BaseProcess> initial_process;
+#ifdef PC_STARTUP_LANGUAGE
+    if (const auto profile = load_startup_language_profile(platform_.files())) {
+        apply_startup_language_profile(*profile);
+        platform_.log("LANGUAGE_PROFILE_LOADED");
+        platform_.log("TITLE_PROCESS_SELECTED");
+        initial_process = std::make_unique<TitleMenuProcess>(*this);
+    } else {
+        platform_.log("LANGUAGE_PROFILE_FRESH");
+        platform_.log("LANGUAGE_PROCESS_SELECTED");
+        initial_process = std::make_unique<StartupLanguageProcess>(*this);
+    }
+#else
+    platform_.log("TITLE_PROCESS_SELECTED");
+    initial_process = std::make_unique<TitleMenuProcess>(*this);
+#endif
+    if (!process_manager_.call_proc(std::move(initial_process)) ||
+            process_manager_.main() != gfl2::proc::ManagerResult::Pushed ||
+            process_manager_.main() != gfl2::proc::ManagerResult::Running ||
+            !process_manager_.current_process_initialized()) {
+        platform_.log("reconstructed native scheduler initialization failed");
+        return false;
+    }
+    startup_point_ = StartupPoint::NativeSchedulerReady;
+    platform_.log("reconstructed process and frame schedulers ready: " +
+                  std::string(process_manager_.current_process()->name()));
+    return true;
+}
+
+void Application::shutdown() {
+    process_manager_.request_end();
+    for (int attempt = 0; attempt < 8 && !process_manager_.empty(); ++attempt) {
+        process_manager_.main();
+    }
+    if (!process_manager_.empty()) {
+        throw std::logic_error("native scheduler did not stop cleanly");
+    }
+    game_manager_.reset();
+}
+
+void Application::update() {
+    if (process_manager_.main() == gfl2::proc::ManagerResult::Empty) {
+        throw std::logic_error("native process scheduler stopped unexpectedly");
+    }
+    process_manager_.draw();
+}
+
+void Application::run_native_frame() {
+    random_.Next();
+    situation_.SetEggStepCount(situation_.GetEggStepCount() + 1);
+    ++frame_count_;
+}
+
+void Application::apply_startup_language_profile(StartupLanguageProfile profile) {
+    startup_language_profile_ = profile;
+    platform_.log("LANGUAGE_APPLIED=" + std::to_string(profile.language) + ":" +
+                  (profile.kanji_mode ? "1" : "0"));
+}
+
+StartupPoint Application::startup_point() const {
+    return startup_point_;
+}
+
+std::uint64_t Application::frame_count() const {
+    return frame_count_;
+}
+
+const char* startup_point_name(StartupPoint point) {
+    switch (point) {
+    case StartupPoint::HostEntry: return "HOST_ENTRY";
+    case StartupPoint::PlatformReady: return "PLATFORM_READY";
+    case StartupPoint::ReconstructedCoreReady: return "RECONSTRUCTED_CORE_READY";
+    case StartupPoint::GameManagerReady: return "GAME_MANAGER_READY";
+    case StartupPoint::NativeSchedulerReady: return "NATIVE_SCHEDULER_READY";
+    }
+    return "UNKNOWN";
+}
+
+} // namespace PokemonMoon

--- a/pc/src/frame_manager.cpp
+++ b/pc/src/frame_manager.cpp
@@ -1,0 +1,153 @@
+#include "pokemoon/frame_manager.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace applib::frame {
+
+struct Manager::Node {
+    explicit Node(std::unique_ptr<CellSuper> value) : cell(std::move(value)) {}
+
+    CellState state = CellState::Created;
+    std::unique_ptr<Node> parent;
+    std::unique_ptr<CellSuper> cell;
+    bool runs_with_parent = false;
+};
+
+Manager::Manager() = default;
+Manager::~Manager() = default;
+
+bool Manager::call_proc(std::unique_ptr<CellSuper> cell) {
+    if (cell == nullptr || pending_ != nullptr) {
+        return false;
+    }
+    pending_ = std::move(cell);
+    pending_mode_ = PendingMode::Call;
+    return true;
+}
+
+bool Manager::parallel_proc(std::unique_ptr<CellSuper> cell) {
+    if (cell == nullptr || pending_ != nullptr) {
+        return false;
+    }
+    pending_ = std::move(cell);
+    pending_mode_ = PendingMode::Parallel;
+    return true;
+}
+
+ManagerResult Manager::main() {
+    if (current_ == nullptr && pending_ == nullptr) {
+        return ManagerResult::Empty;
+    }
+
+    ManagerResult manager_result = ManagerResult::Running;
+    if (pending_ != nullptr) {
+        install_pending();
+        manager_result = ManagerResult::Pushed;
+    }
+
+    const CellState state = current_->state;
+    if (state == CellState::Created) {
+        current_->state = CellState::Initializing;
+    }
+    if (state == CellState::Created || state == CellState::Initializing) {
+        const CallbackResult result = current_->cell->initialize();
+        if (result == CallbackResult::Continue) {
+            return manager_result;
+        }
+        current_->state = CellState::Running;
+        if (result == CallbackResult::AdvanceNextFrame) {
+            return manager_result;
+        }
+    }
+
+    if (current_->state == CellState::Running) {
+        const CallbackResult result = update_active(*current_);
+        if (result == CallbackResult::Continue) {
+            return manager_result;
+        }
+        current_->state = CellState::Ending;
+        if (result == CallbackResult::AdvanceNextFrame) {
+            return manager_result;
+        }
+    }
+
+    if (current_->state == CellState::Ending) {
+        const CallbackResult result = current_->cell->end();
+        if (result == CallbackResult::Continue) {
+            return manager_result;
+        }
+        return finish_current(result);
+    }
+
+    return manager_result;
+}
+
+bool Manager::end() {
+    if (current_ == nullptr && pending_ == nullptr) {
+        return false;
+    }
+    if (current_ != nullptr && current_->state == CellState::Running) {
+        current_->state = CellState::Ending;
+    }
+    return main() != ManagerResult::Empty;
+}
+
+void Manager::draw(std::uint32_t display) {
+    if (current_ == nullptr || current_->state != CellState::Running) {
+        return;
+    }
+
+    draw_active(*current_, display);
+}
+
+CellSuper* Manager::current_cell() {
+    return current_ == nullptr ? nullptr : current_->cell.get();
+}
+
+const CellSuper* Manager::current_cell() const {
+    return current_ == nullptr ? nullptr : current_->cell.get();
+}
+
+CellState Manager::current_state() const {
+    return current_ == nullptr ? CellState::Complete : current_->state;
+}
+
+bool Manager::empty() const {
+    return current_ == nullptr && pending_ == nullptr;
+}
+
+void Manager::install_pending() {
+    auto node = std::make_unique<Node>(std::move(pending_));
+    node->runs_with_parent = pending_mode_ == PendingMode::Parallel;
+    node->parent = std::move(current_);
+    current_ = std::move(node);
+    pending_mode_ = PendingMode::None;
+}
+
+CallbackResult Manager::update_active(Node& node) {
+    if (node.runs_with_parent && node.parent != nullptr) {
+        update_active(*node.parent);
+    }
+    return node.cell->update();
+}
+
+void Manager::draw_active(Node& node, std::uint32_t display) {
+    if (node.runs_with_parent && node.parent != nullptr) {
+        draw_active(*node.parent, display);
+    }
+    node.cell->draw(display);
+}
+
+ManagerResult Manager::finish_current(CallbackResult result) {
+    current_->state = result == CallbackResult::AdvanceNextFrame
+                          ? CellState::Complete
+                          : CellState::Returned;
+    current_ = std::move(current_->parent);
+    if (result == CallbackResult::AdvanceNextFrame) {
+        return ManagerResult::Empty;
+    }
+    return ManagerResult::Transition;
+}
+
+} // namespace applib::frame

--- a/pc/src/game_manager.cpp
+++ b/pc/src/game_manager.cpp
@@ -1,0 +1,51 @@
+#include "pokemoon/game_manager.hpp"
+
+#include <exception>
+#include <stdexcept>
+
+namespace GameSys {
+
+GameManager* GameManager::instance_ = nullptr;
+
+GameManager::GameManager()
+    : heap_(heap_storage_.data(), heap_storage_.size(), std::pmr::null_memory_resource()) {
+    if (instance_ != nullptr) {
+        throw std::logic_error("GameManager singleton already exists");
+    }
+    instance_ = this;
+}
+
+GameManager::~GameManager() {
+    if (instance_ != this) {
+        std::terminate();
+    }
+    instance_ = nullptr;
+}
+
+GameManager* GameManager::instance() {
+    return instance_;
+}
+
+std::pmr::memory_resource& GameManager::heap() {
+    return heap_;
+}
+
+bool GameManager::get_buffer_clear_setting(
+        std::size_t display, BufferClearSetting& setting) const {
+    if (display >= buffer_clear_settings_.size()) {
+        return false;
+    }
+    setting = buffer_clear_settings_[display];
+    return true;
+}
+
+bool GameManager::set_buffer_clear_setting(
+        std::size_t display, const BufferClearSetting& setting) {
+    if (display >= buffer_clear_settings_.size()) {
+        return false;
+    }
+    buffer_clear_settings_[display] = setting;
+    return true;
+}
+
+} // namespace GameSys

--- a/pc/src/main.cpp
+++ b/pc/src/main.cpp
@@ -1,0 +1,98 @@
+#include "pokemoon/application.hpp"
+#include "pokemoon/platform.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Options {
+    Platform::Config platform;
+    std::uint64_t frame_limit = 0;
+};
+
+std::uint64_t parse_count(const std::string& value, const char* option) {
+    std::size_t consumed = 0;
+    const auto parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument(std::string(option) + " requires an integer");
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    if (const char* data_root = std::getenv("POKEMOON_DATA_DIR")) {
+        options.platform.data_root = data_root;
+    } else if (const char* data_root = std::getenv("POKEMOON_DATA_ROOT")) {
+        options.platform.data_root = data_root;
+    } else {
+        options.platform.data_root = "game-data";
+    }
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--data-root" && index + 1 < argc) {
+            options.platform.data_root = argv[++index];
+        } else if (argument == "--frames" && index + 1 < argc) {
+            options.frame_limit = parse_count(argv[++index], "--frames");
+        } else if (argument == "--update-hz" && index + 1 < argc) {
+            const auto rate = parse_count(argv[++index], "--update-hz");
+            if (rate == 0 || rate > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::invalid_argument("--update-hz is out of range");
+            }
+            options.platform.update_hz = static_cast<std::uint32_t>(rate);
+        } else if (argument == "--no-sleep") {
+            options.platform.sleep_enabled = false;
+        } else if (argument == "--headless") {
+            options.platform.graphics_enabled = false;
+        } else {
+            throw std::invalid_argument("unknown or incomplete option: " + argument);
+        }
+    }
+    return options;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const auto options = parse_options(argc, argv);
+        Platform::Runtime platform;
+        if (!platform.initialize(options.platform)) {
+            return 1;
+        }
+
+        PokemonMoon::Application application(platform);
+        if (!application.initialize()) {
+            platform.shutdown();
+            return 1;
+        }
+
+        while (!platform.quit_requested()) {
+            platform.poll_events();
+            if (platform.quit_requested()) {
+                break;
+            }
+            application.update();
+            if (options.frame_limit != 0 && application.frame_count() >= options.frame_limit) {
+                platform.request_quit();
+            }
+            platform.wait_for_next_frame();
+        }
+
+        platform.log(std::string("furthest startup point: ") +
+                     PokemonMoon::startup_point_name(application.startup_point()));
+        platform.log("host update frames: " + std::to_string(application.frame_count()));
+        application.shutdown();
+        platform.shutdown();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "pokemoon-pc: " << error.what() << '\n';
+        return 2;
+    }
+}

--- a/pc/src/platform.cpp
+++ b/pc/src/platform.cpp
@@ -1,0 +1,522 @@
+#include "pokemoon/platform.hpp"
+
+#include <SDL.h>
+#include <SDL_opengl.h>
+
+#include <algorithm>
+#include <csignal>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+
+namespace {
+
+volatile std::sig_atomic_t g_signal_requested = 0;
+
+void handle_signal(int) {
+    g_signal_requested = 1;
+}
+
+} // namespace
+
+namespace Platform {
+
+bool Input::initialize() {
+    if (SDL_InitSubSystem(SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER) != 0) {
+        return false;
+    }
+    initialized_ = true;
+    for (int index = 0; index < SDL_NumJoysticks(); ++index) {
+        if (SDL_IsGameController(index) == SDL_TRUE) {
+            open_controller(index);
+            break;
+        }
+    }
+    return true;
+}
+
+bool Input::poll() {
+    for (auto& state : buttons_) {
+        state.pressed = false;
+        state.released = false;
+    }
+
+    bool quit_requested = false;
+    SDL_Event event{};
+    while (SDL_PollEvent(&event) != 0) {
+        switch (event.type) {
+        case SDL_QUIT:
+            quit_requested = true;
+            break;
+        case SDL_KEYDOWN:
+        case SDL_KEYUP: {
+            if (event.key.repeat != 0) {
+                break;
+            }
+            const bool held = event.type == SDL_KEYDOWN;
+            switch (event.key.keysym.sym) {
+            case SDLK_a: set_button(Button::A, held); break;
+            case SDLK_b: set_button(Button::B, held); break;
+            case SDLK_UP: set_button(Button::Up, held); break;
+            case SDLK_DOWN: set_button(Button::Down, held); break;
+            case SDLK_LEFT: set_button(Button::Left, held); break;
+            case SDLK_RIGHT: set_button(Button::Right, held); break;
+            default: break;
+            }
+            break;
+        }
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP: {
+            const bool held = event.type == SDL_CONTROLLERBUTTONDOWN;
+            switch (event.cbutton.button) {
+            case SDL_CONTROLLER_BUTTON_A: set_button(Button::A, held); break;
+            case SDL_CONTROLLER_BUTTON_B: set_button(Button::B, held); break;
+            case SDL_CONTROLLER_BUTTON_DPAD_UP: set_button(Button::Up, held); break;
+            case SDL_CONTROLLER_BUTTON_DPAD_DOWN: set_button(Button::Down, held); break;
+            case SDL_CONTROLLER_BUTTON_DPAD_LEFT: set_button(Button::Left, held); break;
+            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: set_button(Button::Right, held); break;
+            default: break;
+            }
+            break;
+        }
+        case SDL_CONTROLLERDEVICEADDED:
+            if (controller_ == nullptr) {
+                open_controller(event.cdevice.which);
+            }
+            break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (controller_ != nullptr &&
+                    SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(
+                        static_cast<SDL_GameController*>(controller_))) == event.cdevice.which) {
+                SDL_GameControllerClose(static_cast<SDL_GameController*>(controller_));
+                controller_ = nullptr;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    return quit_requested;
+}
+
+void Input::shutdown() {
+    if (controller_ != nullptr) {
+        SDL_GameControllerClose(static_cast<SDL_GameController*>(controller_));
+        controller_ = nullptr;
+    }
+    if (initialized_) {
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS);
+        initialized_ = false;
+    }
+}
+
+const ButtonState& Input::button(Button button) const {
+    return buttons_.at(static_cast<std::size_t>(button));
+}
+
+void Input::set_button(Button button, bool held) {
+    auto& state = buttons_.at(static_cast<std::size_t>(button));
+    if (state.held == held) {
+        return;
+    }
+    state.held = held;
+    state.pressed = state.pressed || held;
+    state.released = state.released || !held;
+}
+
+void Input::open_controller(int device_index) {
+    controller_ = SDL_GameControllerOpen(device_index);
+}
+
+bool Graphics::initialize() {
+    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
+        return false;
+    }
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    window_ = SDL_CreateWindow("Pokemon Moon PC",
+                               SDL_WINDOWPOS_CENTERED,
+                               SDL_WINDOWPOS_CENTERED,
+                               600,
+                               720,
+                               SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    if (window_ == nullptr) {
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        return false;
+    }
+    context_ = SDL_GL_CreateContext(static_cast<SDL_Window*>(window_));
+    if (context_ == nullptr) {
+        SDL_DestroyWindow(static_cast<SDL_Window*>(window_));
+        window_ = nullptr;
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        return false;
+    }
+    SDL_GL_SetSwapInterval(1);
+    glDisable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    initialized_ = true;
+    return true;
+}
+
+bool Graphics::available() const {
+    return initialized_;
+}
+
+TextureId Graphics::create_texture(const Image& image) {
+    const auto expected_size = static_cast<std::uint64_t>(image.width) * image.height * 4;
+    if (!initialized_ || image.width == 0 || image.height == 0 ||
+            image.rgba.size() != expected_size) {
+        throw std::invalid_argument("invalid RGBA texture image");
+    }
+    GLuint texture = 0;
+    while (glGetError() != GL_NO_ERROR) {
+    }
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D,
+                 0,
+                 GL_RGBA,
+                 static_cast<GLsizei>(image.width),
+                 static_cast<GLsizei>(image.height),
+                 0,
+                 GL_RGBA,
+                 GL_UNSIGNED_BYTE,
+                 image.rgba.data());
+    if (texture == 0 || glGetError() != GL_NO_ERROR) {
+        if (texture != 0) {
+            glDeleteTextures(1, &texture);
+        }
+        throw std::runtime_error("OpenGL title texture upload failed");
+    }
+    return texture;
+}
+
+void Graphics::destroy_texture(TextureId texture) {
+    if (initialized_ && texture != 0) {
+        const auto native_texture = static_cast<GLuint>(texture);
+        glDeleteTextures(1, &native_texture);
+    }
+}
+
+void Graphics::begin_frame() {
+    if (!initialized_) {
+        return;
+    }
+    int width = 0;
+    int height = 0;
+    SDL_GL_GetDrawableSize(static_cast<SDL_Window*>(window_), &width, &height);
+    glViewport(0, 0, width, height);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0.0, 400.0, 480.0, 0.0, -1.0, 1.0);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void Graphics::draw_gradient(float x, float y, float width, float height,
+                             Color top_left, Color top_right,
+                             Color bottom_left, Color bottom_right) {
+    if (!initialized_) {
+        return;
+    }
+    glDisable(GL_TEXTURE_2D);
+    glBegin(GL_QUADS);
+    glColor4ub(top_left.red, top_left.green, top_left.blue, top_left.alpha);
+    glVertex2f(x, y);
+    glColor4ub(top_right.red, top_right.green, top_right.blue, top_right.alpha);
+    glVertex2f(x + width, y);
+    glColor4ub(bottom_right.red, bottom_right.green, bottom_right.blue, bottom_right.alpha);
+    glVertex2f(x + width, y + height);
+    glColor4ub(bottom_left.red, bottom_left.green, bottom_left.blue, bottom_left.alpha);
+    glVertex2f(x, y + height);
+    glEnd();
+}
+
+void Graphics::draw_image(TextureId texture, float x, float y, float width, float height,
+                           float opacity, float u_max, float v_max) {
+    draw_image_tinted(texture, x, y, width, height,
+                      {255, 255, 255, static_cast<std::uint8_t>(
+                          std::clamp(opacity, 0.0f, 1.0f) * 255.0f)}, u_max, v_max);
+}
+
+void Graphics::draw_image_tinted(TextureId texture, float x, float y, float width, float height,
+                                 Color tint, float u_max, float v_max) {
+    if (!initialized_ || texture == 0) {
+        return;
+    }
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glColor4ub(tint.red, tint.green, tint.blue, tint.alpha);
+    glBegin(GL_QUADS);
+    glTexCoord2f(0.0f, 0.0f); glVertex2f(x, y);
+    glTexCoord2f(u_max, 0.0f); glVertex2f(x + width, y);
+    glTexCoord2f(u_max, v_max); glVertex2f(x + width, y + height);
+    glTexCoord2f(0.0f, v_max); glVertex2f(x, y + height);
+    glEnd();
+    glDisable(GL_TEXTURE_2D);
+}
+
+void Graphics::draw_image_rotated(TextureId texture, float center_x, float center_y,
+                                  float width, float height, float rotation_degrees) {
+    if (!initialized_ || texture == 0) {
+        return;
+    }
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glColor4ub(255, 255, 255, 255);
+    glPushMatrix();
+    glTranslatef(center_x, center_y, 0.0f);
+    glRotatef(-rotation_degrees, 0.0f, 0.0f, 1.0f);
+    glBegin(GL_QUADS);
+    glTexCoord2f(0.0f, 0.0f); glVertex2f(-width / 2.0f, -height / 2.0f);
+    glTexCoord2f(1.0f, 0.0f); glVertex2f(width / 2.0f, -height / 2.0f);
+    glTexCoord2f(1.0f, 1.0f); glVertex2f(width / 2.0f, height / 2.0f);
+    glTexCoord2f(0.0f, 1.0f); glVertex2f(-width / 2.0f, height / 2.0f);
+    glEnd();
+    glPopMatrix();
+    glDisable(GL_TEXTURE_2D);
+}
+
+void Graphics::draw_image_region(TextureId texture, float x, float y, float width, float height,
+                                 float u0, float v0, float u1, float v1, Color tint) {
+    if (!initialized_ || texture == 0) {
+        return;
+    }
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glColor4ub(tint.red, tint.green, tint.blue, tint.alpha);
+    glBegin(GL_QUADS);
+    glTexCoord2f(u0, v0); glVertex2f(x, y);
+    glTexCoord2f(u1, v0); glVertex2f(x + width, y);
+    glTexCoord2f(u1, v1); glVertex2f(x + width, y + height);
+    glTexCoord2f(u0, v1); glVertex2f(x, y + height);
+    glEnd();
+    glDisable(GL_TEXTURE_2D);
+}
+
+void Graphics::draw_image_repeated(TextureId texture, float x, float y, float width, float height,
+                                   float u0, float v0, float u1, float v1, Color tint) {
+    if (!initialized_ || texture == 0) {
+        return;
+    }
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    draw_image_region(texture, x, y, width, height, u0, v0, u1, v1, tint);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+}
+
+void Graphics::draw_image_masked(TextureId texture, TextureId mask,
+                                 float x, float y, float width, float height,
+                                 float u0, float v0, float u1, float v1,
+                                 float mask_u0, float mask_v0, float mask_u1, float mask_v1,
+                                 Color tint) {
+    if (!initialized_ || texture == 0 || mask == 0) {
+        return;
+    }
+    glActiveTexture(GL_TEXTURE0);
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+
+    glActiveTexture(GL_TEXTURE1);
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(mask));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+
+    glColor4ub(tint.red, tint.green, tint.blue, tint.alpha);
+    glBegin(GL_QUADS);
+    glMultiTexCoord2f(GL_TEXTURE0, u0, v0);
+    glMultiTexCoord2f(GL_TEXTURE1, mask_u0, mask_v0);
+    glVertex2f(x, y);
+    glMultiTexCoord2f(GL_TEXTURE0, u1, v0);
+    glMultiTexCoord2f(GL_TEXTURE1, mask_u1, mask_v0);
+    glVertex2f(x + width, y);
+    glMultiTexCoord2f(GL_TEXTURE0, u1, v1);
+    glMultiTexCoord2f(GL_TEXTURE1, mask_u1, mask_v1);
+    glVertex2f(x + width, y + height);
+    glMultiTexCoord2f(GL_TEXTURE0, u0, v1);
+    glMultiTexCoord2f(GL_TEXTURE1, mask_u0, mask_v1);
+    glVertex2f(x, y + height);
+    glEnd();
+
+    glDisable(GL_TEXTURE_2D);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(texture));
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glDisable(GL_TEXTURE_2D);
+}
+
+void Graphics::present() {
+    if (initialized_) {
+        SDL_GL_SwapWindow(static_cast<SDL_Window*>(window_));
+    }
+}
+
+void Graphics::shutdown() {
+    if (context_ != nullptr) {
+        SDL_GL_DeleteContext(static_cast<SDL_GLContext>(context_));
+        context_ = nullptr;
+    }
+    if (window_ != nullptr) {
+        SDL_DestroyWindow(static_cast<SDL_Window*>(window_));
+        window_ = nullptr;
+    }
+    if (initialized_) {
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        initialized_ = false;
+    }
+}
+
+FileSystem::FileSystem(std::filesystem::path root)
+    : root_(std::filesystem::absolute(std::move(root)).lexically_normal()) {}
+
+bool FileSystem::available() const {
+    return std::filesystem::is_directory(root_);
+}
+
+const std::filesystem::path& FileSystem::root() const {
+    return root_;
+}
+
+std::filesystem::path FileSystem::resolve(const std::filesystem::path& relative) const {
+    if (relative.empty() || relative.is_absolute()) {
+        throw std::invalid_argument("game-data paths must be non-empty and relative");
+    }
+    for (const auto& part : relative) {
+        if (part == "..") {
+            throw std::invalid_argument("game-data paths may not escape the configured root");
+        }
+    }
+    return (root_ / relative).lexically_normal();
+}
+
+std::filesystem::path FileSystem::resolve_archive(std::uint32_t archive_id,
+                                                  std::uint32_t data_id) const {
+    std::ostringstream relative;
+    relative << "romfs/arc/" << std::hex << std::setfill('0') << std::setw(4) << archive_id
+             << '/' << std::setw(4) << data_id << ".bin";
+    return resolve(relative.str());
+}
+
+std::vector<std::uint8_t> FileSystem::read_binary(const std::filesystem::path& relative) const {
+    const auto path = resolve(relative);
+    std::ifstream stream(path, std::ios::binary | std::ios::ate);
+    if (!stream) {
+        throw std::runtime_error("could not open external game data: " + path.string());
+    }
+    const auto end = stream.tellg();
+    if (end < 0) {
+        throw std::runtime_error("could not size external game data: " + path.string());
+    }
+    std::vector<std::uint8_t> data(static_cast<std::size_t>(end));
+    stream.seekg(0);
+    if (!data.empty() && !stream.read(reinterpret_cast<char*>(data.data()),
+                                      static_cast<std::streamsize>(end))) {
+        throw std::runtime_error("could not read external game data: " + path.string());
+    }
+    return data;
+}
+
+bool Runtime::initialize(const Config& config) {
+    if (config.update_hz == 0) {
+        log("platform initialization failed: update rate must be nonzero");
+        return false;
+    }
+    config_ = config;
+    files_ = FileSystem(config.data_root);
+    if (config.graphics_enabled && !graphics_.initialize()) {
+        log(std::string("platform initialization failed: SDL/OpenGL graphics: ") + SDL_GetError());
+        return false;
+    }
+    if (!input_.initialize()) {
+        log(std::string("platform initialization failed: SDL input: ") + SDL_GetError());
+        graphics_.shutdown();
+        return false;
+    }
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+    next_frame_ = std::chrono::steady_clock::now();
+    initialized_ = true;
+    log("platform initialized: Linux host timing and signal handling ready");
+    log(graphics_.available() ? "graphics initialized: SDL2/OpenGL 400x480 logical surface"
+                              : "graphics disabled: headless host mode");
+    if (files_.available()) {
+        log("external game data: " + files_.root().string());
+    } else {
+        log("external game data unavailable: " + files_.root().string());
+    }
+    return true;
+}
+
+void Runtime::poll_events() {
+    if (input_.poll()) {
+        request_quit();
+    }
+}
+
+bool Runtime::quit_requested() const {
+    return quit_requested_ || g_signal_requested != 0;
+}
+
+void Runtime::request_quit() {
+    quit_requested_ = true;
+}
+
+void Runtime::wait_for_next_frame() {
+    if (!initialized_ || !config_.sleep_enabled) {
+        return;
+    }
+    const auto interval = std::chrono::nanoseconds(1'000'000'000 / config_.update_hz);
+    next_frame_ += interval;
+    const auto now = std::chrono::steady_clock::now();
+    if (next_frame_ < now - interval * 4) {
+        next_frame_ = now;
+    }
+    std::this_thread::sleep_until(next_frame_);
+}
+
+void Runtime::log(const std::string& message) const {
+    std::cerr << "[pokemoon-pc] " << message << '\n';
+}
+
+void Runtime::shutdown() {
+    if (initialized_) {
+        input_.shutdown();
+        graphics_.shutdown();
+        log("platform shutdown complete");
+        initialized_ = false;
+    }
+}
+
+const FileSystem& Runtime::files() const {
+    return files_;
+}
+
+const Input& Runtime::input() const {
+    return input_;
+}
+
+Graphics& Runtime::graphics() {
+    return graphics_;
+}
+
+} // namespace Platform

--- a/pc/src/process_manager.cpp
+++ b/pc/src/process_manager.cpp
@@ -1,0 +1,158 @@
+#include "pokemoon/process_manager.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace gfl2::proc {
+
+struct Manager::Node {
+    explicit Node(std::unique_ptr<BaseProcess> value) : process(std::move(value)) {}
+
+    ProcessState state = ProcessState::Created;
+    std::unique_ptr<Node> parent;
+    std::unique_ptr<BaseProcess> process;
+};
+
+Manager::Manager() = default;
+Manager::~Manager() = default;
+
+bool Manager::call_proc(std::unique_ptr<BaseProcess> process) {
+    if (process == nullptr || pending_ != nullptr) {
+        return false;
+    }
+    pending_ = std::move(process);
+    pending_mode_ = PendingMode::Push;
+    main_active_ = false;
+    end_requested_ = false;
+    return true;
+}
+
+bool Manager::change_proc(std::unique_ptr<BaseProcess> process) {
+    if (process == nullptr || pending_ != nullptr) {
+        return false;
+    }
+    pending_ = std::move(process);
+    pending_mode_ = current_ == nullptr ? PendingMode::Push : PendingMode::Replace;
+    main_active_ = false;
+    return true;
+}
+
+ManagerResult Manager::main() {
+    if (current_ == nullptr && pending_ == nullptr) {
+        return ManagerResult::Empty;
+    }
+
+    ManagerResult result = ManagerResult::Running;
+    if (pending_mode_ == PendingMode::Push) {
+        install_pending(true);
+        end_requested_ = false;
+        result = ManagerResult::Pushed;
+    }
+
+    if (current_ != nullptr && dispatch_current()) {
+        if (pending_mode_ == PendingMode::Replace) {
+            install_pending(false);
+        } else {
+            remove_current();
+            end_requested_ = false;
+        }
+        return ManagerResult::Transition;
+    }
+
+    if (current_ == nullptr && pending_ == nullptr) {
+        return ManagerResult::Empty;
+    }
+    return result;
+}
+
+void Manager::draw() {
+    if (main_active_ && current_ != nullptr) {
+        current_->process->draw(*this);
+    }
+}
+
+void Manager::request_end() {
+    if (current_ != nullptr) {
+        end_requested_ = true;
+    }
+}
+
+BaseProcess* Manager::current_process() {
+    return current_ == nullptr ? nullptr : current_->process.get();
+}
+
+const BaseProcess* Manager::current_process() const {
+    return current_ == nullptr ? nullptr : current_->process.get();
+}
+
+bool Manager::current_process_initialized() const {
+    return pending_ == nullptr && current_ != nullptr &&
+           current_->state == ProcessState::Running;
+}
+
+ProcessState Manager::current_state() const {
+    return current_ == nullptr ? ProcessState::Complete : current_->state;
+}
+
+bool Manager::empty() const {
+    return current_ == nullptr && pending_ == nullptr;
+}
+
+bool Manager::dispatch_current() {
+    const ProcessState state = current_->state;
+    if (state == ProcessState::Created) {
+        current_->state = ProcessState::Initializing;
+    }
+
+    if (state == ProcessState::Created || state == ProcessState::Initializing) {
+        if (current_->process->initialize(*this) == CallbackResult::Finish) {
+            current_->state = ProcessState::Running;
+        }
+        return false;
+    }
+
+    if (state == ProcessState::Running) {
+        const CallbackResult callback_result = current_->process->update(*this);
+        main_active_ = true;
+        if (end_requested_ || callback_result == CallbackResult::Finish) {
+            end_requested_ = false;
+            current_->state = ProcessState::Ending;
+        }
+        return false;
+    }
+
+    if (state == ProcessState::Ending) {
+        main_active_ = false;
+        if (current_->process->end(*this) == CallbackResult::Finish) {
+            current_->state = ProcessState::Complete;
+            return true;
+        }
+    }
+    return false;
+}
+
+void Manager::install_pending(bool preserve_parent) {
+    if (pending_ == nullptr) {
+        throw std::logic_error("process manager has no pending process");
+    }
+
+    auto node = std::make_unique<Node>(std::move(pending_));
+    if (preserve_parent) {
+        node->parent = std::move(current_);
+    } else if (current_ != nullptr) {
+        node->parent = std::move(current_->parent);
+    }
+    current_ = std::move(node);
+    pending_mode_ = PendingMode::None;
+    main_active_ = false;
+    end_requested_ = false;
+}
+
+void Manager::remove_current() {
+    if (current_ == nullptr) {
+        throw std::logic_error("process manager has no current process");
+    }
+    current_ = std::move(current_->parent);
+}
+
+} // namespace gfl2::proc

--- a/pc/src/startup_language.cpp
+++ b/pc/src/startup_language.cpp
@@ -1,0 +1,76 @@
+#include "pokemoon/startup_language.hpp"
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+namespace {
+
+constexpr std::array<std::uint8_t, 8> profile_magic{{'P', 'M', 'L', 'A', 'N', 'G', '0', '1'}};
+constexpr std::uint8_t profile_version = 1;
+constexpr std::size_t profile_size = 16;
+constexpr auto profile_path = "save/startup_language.bin";
+constexpr auto temporary_profile_path = "save/startup_language.bin.tmp";
+
+bool valid_profile(const std::vector<std::uint8_t>& data) {
+    return data.size() == profile_size &&
+           std::equal(profile_magic.begin(), profile_magic.end(), data.begin()) &&
+           data[8] == profile_version && data[9] < 9 && data[10] < 2 &&
+           std::all_of(data.begin() + 11, data.end(), [](std::uint8_t value) {
+               return value == 0;
+           });
+}
+
+} // namespace
+
+namespace PokemonMoon {
+
+std::optional<StartupLanguageProfile> load_startup_language_profile(
+        const Platform::FileSystem& files) {
+    const auto path = files.resolve(profile_path);
+    if (!std::filesystem::is_regular_file(path)) {
+        return std::nullopt;
+    }
+    const auto data = files.read_binary(profile_path);
+    if (!valid_profile(data)) {
+        return std::nullopt;
+    }
+    return StartupLanguageProfile{data[9], data[10] != 0};
+}
+
+void save_startup_language_profile(const Platform::FileSystem& files,
+                                   StartupLanguageProfile profile) {
+    if (profile.language >= 9) {
+        throw std::invalid_argument("startup language is out of range");
+    }
+
+    std::array<std::uint8_t, profile_size> data{};
+    std::copy(profile_magic.begin(), profile_magic.end(), data.begin());
+    data[8] = profile_version;
+    data[9] = profile.language;
+    data[10] = static_cast<std::uint8_t>(profile.kanji_mode);
+
+    const auto path = files.resolve(profile_path);
+    const auto temporary = files.resolve(temporary_profile_path);
+    std::filesystem::create_directories(path.parent_path());
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    try {
+        std::ofstream stream(temporary, std::ios::binary | std::ios::trunc);
+        stream.write(reinterpret_cast<const char*>(data.data()),
+                     static_cast<std::streamsize>(data.size()));
+        stream.flush();
+        if (!stream) {
+            throw std::runtime_error("could not write startup language profile");
+        }
+        stream.close();
+        std::filesystem::rename(temporary, path);
+    } catch (...) {
+        std::filesystem::remove(temporary, ignored);
+        throw;
+    }
+}
+
+} // namespace PokemonMoon

--- a/pc/src/title_resources.cpp
+++ b/pc/src/title_resources.cpp
@@ -1,0 +1,648 @@
+#include "pokemoon/title_resources.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+std::uint16_t read_u16(const std::vector<std::uint8_t>& data, std::size_t offset) {
+    if (offset > data.size() || data.size() - offset < 2) {
+        throw std::runtime_error("truncated retail title resource");
+    }
+    return static_cast<std::uint16_t>(
+        static_cast<std::uint16_t>(data[offset]) |
+        static_cast<std::uint16_t>(data[offset + 1]) << 8);
+}
+
+std::uint32_t read_u32(const std::vector<std::uint8_t>& data, std::size_t offset) {
+    if (offset > data.size() || data.size() - offset < 4) {
+        throw std::runtime_error("truncated retail title resource");
+    }
+    return static_cast<std::uint32_t>(data[offset]) |
+           static_cast<std::uint32_t>(data[offset + 1]) << 8 |
+           static_cast<std::uint32_t>(data[offset + 2]) << 16 |
+           static_cast<std::uint32_t>(data[offset + 3]) << 24;
+}
+
+float read_f32(const std::vector<std::uint8_t>& data, std::size_t offset) {
+    const auto bits = read_u32(data, offset);
+    float value = 0.0f;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+std::string read_fixed_string(const std::vector<std::uint8_t>& data,
+                              std::size_t offset,
+                              std::size_t size) {
+    if (offset > data.size() || data.size() - offset < size) {
+        throw std::runtime_error("truncated retail resource string");
+    }
+    const auto begin = data.begin() + static_cast<std::ptrdiff_t>(offset);
+    const auto end = std::find(begin, begin + static_cast<std::ptrdiff_t>(size), 0);
+    return {begin, end};
+}
+
+void require_magic(const std::vector<std::uint8_t>& data,
+                   std::size_t offset,
+                   const char* magic) {
+    if (offset > data.size() || data.size() - offset < 4 ||
+            !std::equal(magic, magic + 4, data.begin() + static_cast<std::ptrdiff_t>(offset))) {
+        throw std::runtime_error(std::string("missing retail resource section: ") +
+                                 std::string(magic, 4));
+    }
+}
+
+std::vector<std::uint8_t> decompress_lz11(const std::vector<std::uint8_t>& source) {
+    if (source.size() < 4 || source[0] != 0x11) {
+        throw std::runtime_error("title resource is not LZ11 data");
+    }
+    std::uint32_t output_size = static_cast<std::uint32_t>(source[1]) |
+                                static_cast<std::uint32_t>(source[2]) << 8 |
+                                static_cast<std::uint32_t>(source[3]) << 16;
+    std::size_t input = 4;
+    if (output_size == 0) {
+        output_size = read_u32(source, input);
+        input += 4;
+    }
+    if (output_size == 0) {
+        throw std::runtime_error("LZ11 title resource has an empty output");
+    }
+    constexpr std::uint32_t maximum_title_resource_size = 64u * 1024u * 1024u;
+    if (output_size > maximum_title_resource_size) {
+        throw std::runtime_error("LZ11 title resource exceeds the PC decode limit");
+    }
+
+    std::vector<std::uint8_t> output;
+    output.reserve(output_size);
+    while (output.size() < output_size) {
+        if (input >= source.size()) {
+            throw std::runtime_error("truncated LZ11 title resource");
+        }
+        const auto flags = source[input++];
+        for (int bit = 7; bit >= 0 && output.size() < output_size; --bit) {
+            if ((flags & (1u << bit)) == 0) {
+                if (input >= source.size()) {
+                    throw std::runtime_error("truncated LZ11 literal");
+                }
+                output.push_back(source[input++]);
+                continue;
+            }
+            if (source.size() - input < 2) {
+                throw std::runtime_error("truncated LZ11 match");
+            }
+            const auto first = source[input++];
+            const auto second = source[input++];
+            std::size_t length = 0;
+            std::size_t distance = 0;
+            if ((first >> 4) == 0) {
+                if (input >= source.size()) {
+                    throw std::runtime_error("truncated LZ11 long match");
+                }
+                const auto third = source[input++];
+                length = (static_cast<std::size_t>(first & 0x0f) << 4 |
+                          static_cast<std::size_t>(second >> 4)) + 0x11;
+                distance = (static_cast<std::size_t>(second & 0x0f) << 8 | third) + 1;
+            } else if ((first >> 4) == 1) {
+                if (source.size() - input < 2) {
+                    throw std::runtime_error("truncated LZ11 very long match");
+                }
+                const auto third = source[input++];
+                const auto fourth = source[input++];
+                length = (static_cast<std::size_t>(first & 0x0f) << 12 |
+                          static_cast<std::size_t>(second) << 4 |
+                          static_cast<std::size_t>(third >> 4)) + 0x111;
+                distance = (static_cast<std::size_t>(third & 0x0f) << 8 | fourth) + 1;
+            } else {
+                length = static_cast<std::size_t>(first >> 4) + 1;
+                distance = (static_cast<std::size_t>(first & 0x0f) << 8 | second) + 1;
+            }
+            if (distance > output.size()) {
+                throw std::runtime_error("invalid LZ11 match distance");
+            }
+            for (std::size_t index = 0; index < length && output.size() < output_size; ++index) {
+                output.push_back(output[output.size() - distance]);
+            }
+        }
+    }
+    return output;
+}
+
+std::vector<std::uint8_t> extract_sarc(const std::vector<std::uint8_t>& container,
+                                       const std::string& wanted) {
+    const std::array<std::uint8_t, 4> magic{{'S', 'A', 'R', 'C'}};
+    const auto found = std::search(container.begin(), container.end(), magic.begin(), magic.end());
+    if (found == container.end()) {
+        throw std::runtime_error("title ALYT does not contain a SARC");
+    }
+    const auto sarc = static_cast<std::size_t>(std::distance(container.begin(), found));
+    const auto header_size = read_u16(container, sarc + 4);
+    const auto data_offset = read_u32(container, sarc + 12);
+    const auto sfat = sarc + header_size;
+    require_magic(container, sfat, "SFAT");
+    const auto sfat_header_size = read_u16(container, sfat + 4);
+    const auto node_count = read_u16(container, sfat + 6);
+    const auto nodes = sfat + sfat_header_size;
+    const auto sfnt = nodes + static_cast<std::size_t>(node_count) * 16;
+    require_magic(container, sfnt, "SFNT");
+    const auto names = sfnt + read_u16(container, sfnt + 4);
+
+    for (std::size_t index = 0; index < node_count; ++index) {
+        const auto node = nodes + index * 16;
+        const auto name_field = read_u32(container, node + 4);
+        const auto name_offset = names + static_cast<std::size_t>(name_field & 0x00ffffffu) * 4;
+        if (name_offset >= container.size()) {
+            throw std::runtime_error("invalid SARC title resource name offset");
+        }
+        const auto terminator = std::find(container.begin() + static_cast<std::ptrdiff_t>(name_offset),
+                                          container.end(), 0);
+        if (terminator == container.end()) {
+            throw std::runtime_error("unterminated SARC title resource name");
+        }
+        const std::string name(container.begin() + static_cast<std::ptrdiff_t>(name_offset), terminator);
+        if (name != wanted) {
+            continue;
+        }
+        const auto start = sarc + data_offset + read_u32(container, node + 8);
+        const auto end = sarc + data_offset + read_u32(container, node + 12);
+        if (start > end || end > container.size()) {
+            throw std::runtime_error("invalid SARC title resource extent");
+        }
+        return {container.begin() + static_cast<std::ptrdiff_t>(start),
+                container.begin() + static_cast<std::ptrdiff_t>(end)};
+    }
+    throw std::runtime_error("missing SARC title resource: " + wanted);
+}
+
+std::uint32_t next_power_of_two(std::uint32_t value) {
+    std::uint32_t result = 8;
+    while (result < value) {
+        if (result > std::numeric_limits<std::uint32_t>::max() / 2) {
+            throw std::runtime_error("BFLIM title texture dimensions overflow");
+        }
+        result *= 2;
+    }
+    return result;
+}
+
+std::pair<std::size_t, std::size_t> bflim_destination(std::size_t source_pixel,
+                                                      std::size_t padded_width,
+                                                      std::size_t padded_height,
+                                                      std::uint8_t orientation) {
+    const auto stride = orientation == 0 || orientation == 2
+        ? padded_width : padded_height;
+    const auto macro = source_pixel / 64;
+    const auto within = source_pixel & 63;
+    const auto tiled_x = (macro % (stride / 8)) * 8 +
+                         (within & 1) + ((within >> 1) & 2) + ((within >> 2) & 4);
+    const auto tiled_y = (macro / (stride / 8)) * 8 +
+                         ((within >> 1) & 1) + ((within >> 2) & 2) +
+                         ((within >> 3) & 4);
+    if (orientation == 8) {
+        return {tiled_y, tiled_x};
+    }
+    if (orientation == 4) {
+        return {tiled_y, padded_height - 1 - tiled_x};
+    }
+    if (orientation == 2) {
+        return {tiled_x, padded_height - 1 - tiled_y};
+    }
+    return {tiled_x, tiled_y};
+}
+
+std::uint8_t clamp_channel(int value) {
+    return static_cast<std::uint8_t>(std::max(0, std::min(value, 255)));
+}
+
+int sign3(int value) {
+    return (value + 4) % 8 - 4;
+}
+
+std::array<std::array<std::uint8_t, 4>, 16> decode_etc1_block(
+        const std::vector<std::uint8_t>& source,
+        std::size_t offset) {
+    static constexpr std::array<std::array<int, 4>, 8> modifiers{{
+        {{2, 8, -2, -8}}, {{5, 17, -5, -17}}, {{9, 29, -9, -29}},
+        {{13, 42, -13, -42}}, {{18, 60, -18, -60}}, {{24, 80, -24, -80}},
+        {{33, 106, -33, -106}}, {{47, 183, -47, -183}},
+    }};
+    static constexpr std::array<int, 16> order{{
+        0, 4, 1, 5, 8, 12, 9, 13, 2, 6, 3, 7, 10, 14, 11, 15,
+    }};
+    if (offset > source.size() || source.size() - offset < 8) {
+        throw std::runtime_error("truncated ETC1 title texture");
+    }
+    const auto lsb = read_u16(source, offset);
+    const auto msb = read_u16(source, offset + 2);
+    const auto flags = source[offset + 4];
+    const auto blue = source[offset + 5];
+    const auto green = source[offset + 6];
+    const auto red = source[offset + 7];
+    const bool differential = (flags & 2) != 0;
+    const int depth = differential ? 32 : 16;
+    std::array<int, 3> base0{{red * depth / 256, green * depth / 256,
+                              blue * depth / 256}};
+    std::array<int, 3> base1{};
+    if (differential) {
+        base1 = {{base0[0] + sign3(red & 7), base0[1] + sign3(green & 7),
+                  base0[2] + sign3(blue & 7)}};
+        if (std::any_of(base1.begin(), base1.end(), [](int channel) {
+                return channel < 0 || channel > 31;
+            })) {
+            throw std::runtime_error("invalid ETC1 differential title block");
+        }
+    } else {
+        base1 = {{red & 15, green & 15, blue & 15}};
+    }
+    for (auto* base : {&base0, &base1}) {
+        for (auto& channel : *base) {
+            channel = depth == 16 ? channel * 17 : (channel << 3) | (channel >> 2);
+        }
+    }
+
+    std::array<std::array<std::uint8_t, 4>, 16> pixels{};
+    const int flip_mask = (flags & 1) != 0 ? 2 : 8;
+    for (std::size_t output = 0; output < order.size(); ++output) {
+        const int index = order[output];
+        const bool second = (index & flip_mask) != 0;
+        const auto& base = second ? base1 : base0;
+        const auto table = static_cast<std::size_t>((flags >> (second ? 2 : 5)) & 7);
+        const auto selector = static_cast<std::size_t>(((msb >> index) & 1) * 2 +
+                                                       ((lsb >> index) & 1));
+        const auto modifier = modifiers[table][selector];
+        pixels[output] = {{clamp_channel(base[0] + modifier),
+                           clamp_channel(base[1] + modifier),
+                           clamp_channel(base[2] + modifier), 255}};
+    }
+    return pixels;
+}
+
+Platform::Image decode_bflim(const std::vector<std::uint8_t>& source) {
+    const std::array<std::uint8_t, 4> magic{{'F', 'L', 'I', 'M'}};
+    const auto found = std::find_end(source.begin(), source.end(), magic.begin(), magic.end());
+    if (found == source.end()) {
+        throw std::runtime_error("title texture is not BFLIM data");
+    }
+    const auto footer = static_cast<std::size_t>(std::distance(source.begin(), found));
+    require_magic(source, footer + 20, "imag");
+    const auto width = read_u16(source, footer + 28);
+    const auto height = read_u16(source, footer + 30);
+    const auto format = source.at(footer + 34);
+    const auto orientation = source.at(footer + 35);
+    if (orientation != 0 && orientation != 2 && orientation != 4 && orientation != 8) {
+        throw std::runtime_error("unsupported title BFLIM orientation");
+    }
+    const auto data_size = read_u32(source, footer + 36);
+    const auto bytes_per_pixel = format == 9 ? 4u :
+                                 format == 8 || format == 5 ? 2u : 0u;
+    const auto bits_per_pixel = format == 10 || format == 12 || format == 13 ? 4u :
+                                 format == 11 ? 8u :
+                                 format <= 2 ? 8u :
+                                 bytes_per_pixel * 8u;
+    if (width == 0 || height == 0 || bits_per_pixel == 0) {
+        throw std::runtime_error("unsupported title BFLIM texture format");
+    }
+    const auto padded_width = next_power_of_two(width);
+    const auto padded_height = next_power_of_two(height);
+    const auto expected_size = static_cast<std::uint64_t>(padded_width) * padded_height *
+                               bits_per_pixel / 8;
+    constexpr std::uint64_t maximum_title_pixels = 16u * 1024u * 1024u;
+    if (static_cast<std::uint64_t>(width) * height > maximum_title_pixels ||
+            data_size != expected_size || data_size > source.size() || footer != data_size) {
+        throw std::runtime_error("invalid title BFLIM texture size");
+    }
+
+    Platform::Image image;
+    image.width = width;
+    image.height = height;
+    image.rgba.resize(static_cast<std::size_t>(width) * height * 4);
+    const auto write_pixel = [&](std::size_t pixel, const std::array<std::uint8_t, 4>& rgba) {
+        const auto [x, y] = bflim_destination(pixel, padded_width, padded_height, orientation);
+        if (x >= width || y >= height) {
+            return;
+        }
+        const auto output = (y * width + x) * 4;
+        std::copy(rgba.begin(), rgba.end(), image.rgba.begin() +
+                  static_cast<std::ptrdiff_t>(output));
+    };
+    if (format == 10 || format == 11) {
+        std::size_t pixel = 0;
+        const auto block_size = format == 11 ? 16u : 8u;
+        for (std::size_t input = 0; input < data_size; input += block_size) {
+            auto block = decode_etc1_block(source, input + (format == 11 ? 8u : 0u));
+            if (format == 11) {
+                for (std::size_t index = 0; index < block.size(); ++index) {
+                    block[index][3] = static_cast<std::uint8_t>(
+                        ((source[input + index / 2] >> ((index & 1) * 4)) & 0x0f) * 17);
+                }
+            }
+            for (const auto& rgba : block) {
+                write_pixel(pixel++, rgba);
+            }
+        }
+        return image;
+    }
+    for (std::size_t pixel = 0;
+            pixel < static_cast<std::size_t>(padded_width) * padded_height;
+            ++pixel) {
+            const auto [x, y] = bflim_destination(pixel, padded_width, padded_height,
+                                                  orientation);
+            if (x >= width || y >= height) {
+                continue;
+            }
+            const auto input = format == 12 || format == 13 ? pixel / 2 :
+                               format <= 2 ? pixel : pixel * bytes_per_pixel;
+            const auto output = (y * width + x) * 4;
+            if (format == 9) {
+                image.rgba[output] = source[input + 3];
+                image.rgba[output + 1] = source[input + 2];
+                image.rgba[output + 2] = source[input + 1];
+                image.rgba[output + 3] = source[input];
+            } else if (format == 8) {
+                const auto packed = static_cast<std::uint16_t>(source[input]) |
+                                    static_cast<std::uint16_t>(source[input + 1]) << 8;
+                image.rgba[output] = static_cast<std::uint8_t>(((packed >> 12) & 0x0f) * 17);
+                image.rgba[output + 1] = static_cast<std::uint8_t>(((packed >> 8) & 0x0f) * 17);
+                image.rgba[output + 2] = static_cast<std::uint8_t>(((packed >> 4) & 0x0f) * 17);
+                image.rgba[output + 3] = static_cast<std::uint8_t>((packed & 0x0f) * 17);
+            } else if (format == 5) {
+                const auto packed = static_cast<std::uint16_t>(source[input]) |
+                                    static_cast<std::uint16_t>(source[input + 1]) << 8;
+                image.rgba[output] = static_cast<std::uint8_t>(
+                    ((packed >> 11) & 0x1f) * 255 / 31);
+                image.rgba[output + 1] = static_cast<std::uint8_t>(
+                    ((packed >> 5) & 0x3f) * 255 / 63);
+                image.rgba[output + 2] = static_cast<std::uint8_t>(
+                    (packed & 0x1f) * 255 / 31);
+                image.rgba[output + 3] = 255;
+            } else if (format == 0) {
+                image.rgba[output] = source[input];
+                image.rgba[output + 1] = source[input];
+                image.rgba[output + 2] = source[input];
+                image.rgba[output + 3] = 255;
+            } else if (format == 1) {
+                image.rgba[output] = 255;
+                image.rgba[output + 1] = 255;
+                image.rgba[output + 2] = 255;
+                image.rgba[output + 3] = source[input];
+            } else if (format == 13) {
+                const auto alpha = static_cast<std::uint8_t>(
+                    ((source[input] >> ((pixel & 1) * 4)) & 0x0f) * 17);
+                image.rgba[output] = 255;
+                image.rgba[output + 1] = 255;
+                image.rgba[output + 2] = 255;
+                image.rgba[output + 3] = alpha;
+            } else if (format == 12) {
+                const auto luminance = static_cast<std::uint8_t>(
+                    ((source[input] >> ((pixel & 1) * 4)) & 0x0f) * 17);
+                image.rgba[output] = luminance;
+                image.rgba[output + 1] = luminance;
+                image.rgba[output + 2] = luminance;
+                image.rgba[output + 3] = 255;
+            } else {
+                const auto luminance = static_cast<std::uint8_t>((source[input] >> 4) * 17);
+                image.rgba[output] = luminance;
+                image.rgba[output + 1] = luminance;
+                image.rgba[output + 2] = luminance;
+                image.rgba[output + 3] = static_cast<std::uint8_t>((source[input] & 0x0f) * 17);
+            }
+    }
+    return image;
+}
+
+PokemonMoon::LayoutAnimation decode_bflan(const std::vector<std::uint8_t>& source) {
+    require_magic(source, 0, "FLAN");
+    if (read_u16(source, 4) != 0xfeff || read_u16(source, 6) != 20 ||
+            read_u32(source, 12) != source.size()) {
+        throw std::runtime_error("invalid startup layout animation header");
+    }
+    PokemonMoon::LayoutAnimation animation;
+    auto section = std::size_t{20};
+    const auto section_count = read_u16(source, 16);
+    for (std::size_t section_index = 0; section_index < section_count; ++section_index) {
+        if (section > source.size() || source.size() - section < 8) {
+            throw std::runtime_error("truncated startup layout animation section");
+        }
+        const auto section_size = static_cast<std::size_t>(read_u32(source, section + 4));
+        if (section_size < 8 || section_size > source.size() - section) {
+            throw std::runtime_error("invalid startup layout animation section size");
+        }
+        if (read_fixed_string(source, section, 4) != "pai1") {
+            section += section_size;
+            continue;
+        }
+        animation.frame_count = read_u16(source, section + 8);
+        animation.loop = source.at(section + 10) != 0;
+        const auto texture_count = read_u16(source, section + 12);
+        const auto content_count = read_u16(source, section + 14);
+        const auto content_table = section + read_u32(source, section + 16);
+        if (content_table > section + section_size ||
+                static_cast<std::size_t>(content_count) * 4 >
+                    section + section_size - content_table) {
+            throw std::runtime_error("invalid startup animation content table");
+        }
+        static_cast<void>(texture_count);
+        for (std::size_t content_index = 0; content_index < content_count; ++content_index) {
+            const auto content = section + read_u32(source, content_table + content_index * 4);
+            if (content > section + section_size || section + section_size - content < 32) {
+                throw std::runtime_error("invalid startup animation content");
+            }
+            const auto target_name = read_fixed_string(source, content, 28);
+            const auto tag_count = source.at(content + 28);
+            const auto target_type = source.at(content + 29);
+            for (std::size_t tag_index = 0; tag_index < tag_count; ++tag_index) {
+                auto tag = content + read_u32(source, content + 32 + tag_index * 4);
+                if (target_type == 2) {
+                    tag += 4;
+                }
+                if (tag > section + section_size || section + section_size - tag < 8) {
+                    throw std::runtime_error("invalid startup animation tag");
+                }
+                const auto tag_name = read_fixed_string(source, tag, 4);
+                const auto target_count = source.at(tag + 4);
+                for (std::size_t target_index = 0; target_index < target_count; ++target_index) {
+                    const auto target = tag + read_u32(source, tag + 8 + target_index * 4);
+                    if (target > section + section_size || section + section_size - target < 12) {
+                        throw std::runtime_error("invalid startup animation target");
+                    }
+                    PokemonMoon::LayoutAnimationTrack track;
+                    track.target = target_name;
+                    track.tag = tag_name;
+                    track.component = source.at(target);
+                    track.channel = source.at(target + 1);
+                    const auto curve = source.at(target + 2);
+                    if (curve > static_cast<std::uint8_t>(
+                            PokemonMoon::LayoutAnimationCurve::Hermite)) {
+                        throw std::runtime_error("unsupported startup animation curve");
+                    }
+                    track.curve = static_cast<PokemonMoon::LayoutAnimationCurve>(curve);
+                    const auto key_count = read_u16(source, target + 4);
+                    auto key = target + read_u32(source, target + 8);
+                    for (std::size_t key_index = 0; key_index < key_count; ++key_index) {
+                        PokemonMoon::LayoutAnimationKey decoded_key;
+                        if (track.curve == PokemonMoon::LayoutAnimationCurve::Hermite) {
+                            decoded_key.frame = read_f32(source, key);
+                            decoded_key.value = read_f32(source, key + 4);
+                            decoded_key.slope = read_f32(source, key + 8);
+                            key += 12;
+                        } else if (track.curve == PokemonMoon::LayoutAnimationCurve::Step) {
+                            decoded_key.frame = read_f32(source, key);
+                            decoded_key.value = static_cast<float>(read_u16(source, key + 4));
+                            key += 8;
+                        } else {
+                            decoded_key.frame = static_cast<float>(key_index);
+                            decoded_key.value = read_f32(source, key);
+                            key += 4;
+                        }
+                        if (!std::isfinite(decoded_key.frame) ||
+                                !std::isfinite(decoded_key.value) ||
+                                !std::isfinite(decoded_key.slope)) {
+                            throw std::runtime_error("non-finite startup animation key");
+                        }
+                        track.keys.push_back(decoded_key);
+                    }
+                    animation.tracks.push_back(std::move(track));
+                }
+            }
+        }
+        section += section_size;
+    }
+    if (animation.frame_count == 0 || animation.tracks.empty()) {
+        throw std::runtime_error("startup layout animation has no playable tracks");
+    }
+    return animation;
+}
+
+} // namespace
+
+namespace PokemonMoon {
+
+TitleMenuResources decode_title_menu_resources(
+    const std::vector<std::uint8_t>& title_layout_archive,
+    const std::vector<std::uint8_t>& common_layout_archive) {
+    const auto title_layout = decompress_lz11(title_layout_archive);
+    const auto common_layout = decompress_lz11(common_layout_archive);
+    require_magic(title_layout, 0, "ALYT");
+    require_magic(common_layout, 0, "ALYT");
+    auto sea_pattern = decode_bflim(extract_sarc(
+        title_layout, "timg/LangSel_BG_sea_tex.bflim"));
+    const auto sea_mask = decode_bflim(extract_sarc(
+        title_layout, "timg/LangSel_BG_sea.bflim"));
+    if (sea_pattern.width != sea_mask.width || sea_pattern.height != sea_mask.height) {
+        throw std::runtime_error("title sea texture and mask dimensions differ");
+    }
+    for (std::size_t offset = 3; offset < sea_pattern.rgba.size(); offset += 4) {
+        sea_pattern.rgba[offset] = sea_mask.rgba[offset];
+    }
+    return {
+        decode_bflim(extract_sarc(title_layout, "timg/LangSel_BG_UPP_00.bflim")),
+        std::move(sea_pattern),
+        decode_bflim(extract_sarc(title_layout, "timg/Common_BG_PTN_01.bflim")),
+        decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Report_BG_00.bflim")),
+        decode_bflim(extract_sarc(common_layout, "timg/Common_Cursor_02.bflim")),
+        {{
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Yellow.bflim")),
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Yellow_c.bflim")),
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Yellow_r.bflim")),
+        }},
+        {{
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Red.bflim")),
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Red_c.bflim")),
+            decode_bflim(extract_sarc(title_layout, "timg/TitleMenu_Button_BG_Red_r.bflim")),
+        }},
+    };
+}
+
+StartupLanguageResources decode_startup_language_resources(
+        const std::vector<std::uint8_t>& language_layout_archive,
+        const std::vector<std::uint8_t>& common_layout_archive) {
+    const auto layout = decompress_lz11(language_layout_archive);
+    auto common_layout = layout;
+    if (!common_layout_archive.empty()) {
+        common_layout = decompress_lz11(common_layout_archive);
+        require_magic(common_layout, 0, "ALYT");
+    }
+    auto sea_pattern = decode_bflim(extract_sarc(
+        layout, "timg/LangSel_BG_sea_tex.bflim"));
+    auto sea_pattern_1 = decode_bflim(extract_sarc(
+        layout, "timg/LangSel_BG_sea_tex_01.bflim"));
+    auto sea_mask = decode_bflim(extract_sarc(
+        layout, "timg/LangSel_BG_sea.bflim"));
+    if (sea_pattern.width != sea_mask.width || sea_pattern.height != sea_mask.height ||
+            sea_pattern_1.width != sea_mask.width || sea_pattern_1.height != sea_mask.height) {
+        throw std::runtime_error("language sea texture and mask dimensions differ");
+    }
+    for (std::size_t offset = 0; offset < sea_pattern.rgba.size(); offset += 4) {
+        const auto luminance = sea_pattern.rgba[offset];
+        sea_pattern.rgba[offset] = static_cast<std::uint8_t>(25 + luminance * 50 / 255);
+        sea_pattern.rgba[offset + 1] = static_cast<std::uint8_t>(185 + luminance * 45 / 255);
+        sea_pattern.rgba[offset + 2] = static_cast<std::uint8_t>(200 + luminance * 35 / 255);
+    }
+    std::array<Platform::Image, 9> languages{{
+        decode_bflim(extract_sarc(layout, "timg/lang_select_jp.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_usa.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_esp.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_fra.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_deu.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_ita.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_kor.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_trad.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/lang_select_simp.bflim")),
+    }};
+    for (auto& language : languages) {
+        for (std::size_t offset = 0; offset < language.rgba.size(); offset += 4) {
+            language.rgba[offset] = 0x23;
+            language.rgba[offset + 1] = 0x3a;
+            language.rgba[offset + 2] = 0x3b;
+        }
+    }
+    return {
+        decode_bflim(extract_sarc(layout, "timg/LangSel_BG_UPP_00.bflim")),
+        std::move(sea_pattern),
+        std::move(sea_pattern_1),
+        std::move(sea_mask),
+        decode_bflim(extract_sarc(layout, "timg/LangSel_Plate_00.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/LangSel_Plate_01.bflim")),
+        {{
+            decode_bflim(extract_sarc(layout, "timg/langSel_Button_00.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/langSel_Button_01.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/langSel_Button_00a.bflim")),
+        }},
+        {{
+            decode_bflim(extract_sarc(layout, "timg/SelectButton_Basic_White_00.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/SelectButton_Basic_White_01.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/SelectButton_Basic_White_02.bflim")),
+        }},
+        decode_bflim(extract_sarc(layout, "timg/LangSel_ukiwa.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/LangSel_ukiwa_01.bflim")),
+        {{
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Tail.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Body.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_RK.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_LK.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_RP.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_LP.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Head.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_R_Ear.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_L_Ear.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Eye_00.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Eye_01.bflim")),
+            decode_bflim(extract_sarc(layout, "timg/LangSel_pika_Eye_02.bflim")),
+        }},
+        std::move(languages),
+        decode_bflim(extract_sarc(layout, "timg/Common_BG_PTN_00.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/Common_BG_PTN_01.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/Window_Basic_00.bflim")),
+        decode_bflim(extract_sarc(layout, "timg/Window_Basic_01.bflim")),
+        decode_bflim(extract_sarc(common_layout, "timg/Common_Cursor_02.bflim")),
+        decode_bflan(extract_sarc(layout, "anim/LangSelect_MIN_UPP_Chara_00.bflan")),
+        decode_bflan(extract_sarc(layout, "anim/LangSelect_MIN_UPP_BG_Loop_00.bflan")),
+        decode_bflan(extract_sarc(layout, "anim/Common_BG_LOW_00_bg_loop_00.bflan")),
+    };
+}
+
+} // namespace PokemonMoon

--- a/pc/tests/game_manager_test.cpp
+++ b/pc/tests/game_manager_test.cpp
@@ -1,0 +1,38 @@
+#include "pokemoon/game_manager.hpp"
+
+#include <cstddef>
+#include <stdexcept>
+
+int main() {
+    if (GameSys::GameManager::instance() != nullptr) {
+        return 1;
+    }
+    {
+        GameSys::GameManager manager;
+        if (GameSys::GameManager::instance() != &manager) {
+            return 2;
+        }
+
+        GameSys::BufferClearSetting setting;
+        if (!manager.get_buffer_clear_setting(0, setting) || setting.depth != 1.0f ||
+                setting.stencil != 0xff || setting.clear_mask != 0x03) {
+            return 3;
+        }
+        if (manager.get_buffer_clear_setting(GameSys::GameManager::DisplayCount, setting)) {
+            return 4;
+        }
+
+        void* allocation = manager.heap().allocate(64, alignof(std::max_align_t));
+        if (allocation == nullptr) {
+            return 5;
+        }
+        manager.heap().deallocate(allocation, 64, alignof(std::max_align_t));
+
+        try {
+            GameSys::GameManager duplicate;
+            return 6;
+        } catch (const std::logic_error&) {
+        }
+    }
+    return GameSys::GameManager::instance() == nullptr ? 0 : 7;
+}

--- a/pc/tests/scheduler_test.cpp
+++ b/pc/tests/scheduler_test.cpp
@@ -1,0 +1,184 @@
+#include "pokemoon/frame_manager.hpp"
+#include "pokemoon/process_manager.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+class RecordingProcess final : public gfl2::proc::BaseProcess {
+public:
+    RecordingProcess(
+            std::vector<std::string>& events,
+            std::string prefix = "process",
+            gfl2::proc::CallbackResult update_result = gfl2::proc::CallbackResult::Continue)
+        : events_(events), prefix_(std::move(prefix)), update_result_(update_result) {}
+
+    gfl2::proc::CallbackResult initialize(gfl2::proc::Manager&) override {
+        events_.push_back(prefix_ + ".init");
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    gfl2::proc::CallbackResult update(gfl2::proc::Manager&) override {
+        events_.push_back(prefix_ + ".main");
+        return update_result_;
+    }
+
+    void draw(gfl2::proc::Manager&) override {
+        events_.push_back(prefix_ + ".draw");
+    }
+
+    gfl2::proc::CallbackResult end(gfl2::proc::Manager&) override {
+        events_.push_back(prefix_ + ".end");
+        return gfl2::proc::CallbackResult::Finish;
+    }
+
+    std::string_view name() const override {
+        return "RecordingProcess";
+    }
+
+private:
+    std::vector<std::string>& events_;
+    std::string prefix_;
+    gfl2::proc::CallbackResult update_result_;
+};
+
+class RecordingCell final : public applib::frame::CellSuper {
+public:
+    RecordingCell(std::vector<std::string>& events, std::string prefix = "cell")
+        : events_(events), prefix_(std::move(prefix)) {}
+
+    applib::frame::CallbackResult initialize() override {
+        events_.push_back(prefix_ + ".init");
+        return applib::frame::CallbackResult::Advance;
+    }
+
+    applib::frame::CallbackResult update() override {
+        events_.push_back(prefix_ + ".main");
+        return applib::frame::CallbackResult::Continue;
+    }
+
+    void draw(std::uint32_t) override {
+        events_.push_back(prefix_ + ".draw");
+    }
+
+    applib::frame::CallbackResult end() override {
+        events_.push_back(prefix_ + ".end");
+        return applib::frame::CallbackResult::Advance;
+    }
+
+private:
+    std::vector<std::string>& events_;
+    std::string prefix_;
+};
+
+bool process_lifecycle_matches() {
+    std::vector<std::string> events;
+    gfl2::proc::Manager manager;
+    if (!manager.call_proc(std::make_unique<RecordingProcess>(events)) ||
+            manager.main() != gfl2::proc::ManagerResult::Pushed ||
+            !manager.current_process_initialized()) {
+        return false;
+    }
+    manager.draw();
+    if (events != std::vector<std::string>{"process.init"}) {
+        return false;
+    }
+    if (manager.main() != gfl2::proc::ManagerResult::Running) {
+        return false;
+    }
+    manager.draw();
+    manager.request_end();
+    manager.main();
+    if (manager.current_state() != gfl2::proc::ProcessState::Ending) {
+        return false;
+    }
+    if (manager.main() != gfl2::proc::ManagerResult::Transition || !manager.empty()) {
+        return false;
+    }
+    return events == std::vector<std::string>{
+                         "process.init", "process.main", "process.draw",
+                         "process.main", "process.end"};
+}
+
+bool frame_lifecycle_matches() {
+    std::vector<std::string> events;
+    applib::frame::Manager manager;
+    if (!manager.call_proc(std::make_unique<RecordingCell>(events)) ||
+            manager.main() != applib::frame::ManagerResult::Pushed ||
+            manager.current_state() != applib::frame::CellState::Running) {
+        return false;
+    }
+    manager.draw(0);
+    if (manager.main() != applib::frame::ManagerResult::Running || !manager.end() ||
+            manager.end() || !manager.empty()) {
+        return false;
+    }
+    return events == std::vector<std::string>{
+                         "cell.init", "cell.main", "cell.draw", "cell.main", "cell.end"};
+}
+
+bool process_replacement_matches() {
+    std::vector<std::string> events;
+    gfl2::proc::Manager manager;
+    if (!manager.call_proc(std::make_unique<RecordingProcess>(
+                events, "old", gfl2::proc::CallbackResult::Finish)) ||
+            manager.main() != gfl2::proc::ManagerResult::Pushed ||
+            !manager.change_proc(std::make_unique<RecordingProcess>(events, "new"))) {
+        return false;
+    }
+    if (manager.main() != gfl2::proc::ManagerResult::Running ||
+            manager.main() != gfl2::proc::ManagerResult::Transition ||
+            manager.main() != gfl2::proc::ManagerResult::Running) {
+        return false;
+    }
+    manager.request_end();
+    manager.main();
+    if (manager.main() != gfl2::proc::ManagerResult::Transition || !manager.empty()) {
+        return false;
+    }
+    return events == std::vector<std::string>{
+                         "old.init", "old.main", "old.end", "new.init", "new.main",
+                         "new.end"};
+}
+
+bool parallel_frame_order_matches() {
+    std::vector<std::string> events;
+    applib::frame::Manager manager;
+    if (!manager.call_proc(std::make_unique<RecordingCell>(events, "parent")) ||
+            manager.main() != applib::frame::ManagerResult::Pushed ||
+            !manager.parallel_proc(std::make_unique<RecordingCell>(events, "child")) ||
+            manager.main() != applib::frame::ManagerResult::Pushed) {
+        return false;
+    }
+    manager.draw(0);
+    if (!manager.end() || !manager.end() || manager.end()) {
+        return false;
+    }
+    return events == std::vector<std::string>{
+                         "parent.init", "parent.main", "child.init", "parent.main",
+                         "child.main", "parent.draw", "child.draw", "child.end",
+                         "parent.end"};
+}
+
+} // namespace
+
+int main() {
+    if (!process_lifecycle_matches()) {
+        return 1;
+    }
+    if (!frame_lifecycle_matches()) {
+        return 2;
+    }
+    if (!process_replacement_matches()) {
+        return 3;
+    }
+    if (!parallel_frame_order_matches()) {
+        return 4;
+    }
+    return 0;
+}

--- a/pc/tests/startup_language_process_test.cpp
+++ b/pc/tests/startup_language_process_test.cpp
@@ -1,0 +1,98 @@
+#include "pokemoon/application.hpp"
+#include "pokemoon/platform.hpp"
+#include "pokemoon/startup_language.hpp"
+
+#include <SDL.h>
+
+#include <chrono>
+#include <filesystem>
+#include <stdexcept>
+
+namespace {
+
+void update(PokemonMoon::Application& application, Platform::Runtime& platform, int count = 1) {
+    for (int frame = 0; frame < count; ++frame) {
+        platform.poll_events();
+        application.update();
+    }
+}
+
+void key(PokemonMoon::Application& application,
+         Platform::Runtime& platform,
+         SDL_Keycode value,
+         bool pressed) {
+    SDL_Event event{};
+    event.type = pressed ? SDL_KEYDOWN : SDL_KEYUP;
+    event.key.repeat = 0;
+    event.key.keysym.sym = value;
+    if (SDL_PushEvent(&event) != 1) {
+        throw std::runtime_error("could not inject startup language input");
+    }
+    update(application, platform);
+}
+
+} // namespace
+
+int main() {
+    const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+                      ("pokemoon-startup-language-process-" + std::to_string(suffix));
+    try {
+        Platform::Config config;
+        config.data_root = root;
+        config.sleep_enabled = false;
+        config.graphics_enabled = false;
+
+        Platform::Runtime platform;
+        if (!platform.initialize(config)) {
+            throw std::runtime_error("platform initialization failed");
+        }
+        PokemonMoon::Application application(platform);
+        if (!application.initialize()) {
+            throw std::runtime_error("application initialization failed");
+        }
+
+        key(application, platform, SDLK_DOWN, true);
+        key(application, platform, SDLK_DOWN, false);
+        key(application, platform, SDLK_a, true);
+        key(application, platform, SDLK_a, false);
+        update(application, platform, 14);
+        key(application, platform, SDLK_b, true);
+        if (PokemonMoon::load_startup_language_profile(platform.files())) {
+            throw std::runtime_error("cancel persisted a startup language");
+        }
+        key(application, platform, SDLK_b, false);
+
+        key(application, platform, SDLK_a, true);
+        key(application, platform, SDLK_a, false);
+        update(application, platform, 14);
+        key(application, platform, SDLK_a, true);
+        const auto profile = PokemonMoon::load_startup_language_profile(platform.files());
+        if (!profile || profile->language != 2 || profile->kanji_mode) {
+            throw std::runtime_error("confirmed startup language was not persisted");
+        }
+        key(application, platform, SDLK_a, false);
+        update(application, platform, 4);
+
+        application.shutdown();
+        platform.shutdown();
+
+        Platform::Runtime returning_platform;
+        if (!returning_platform.initialize(config)) {
+            throw std::runtime_error("returning platform initialization failed");
+        }
+        PokemonMoon::Application returning_application(returning_platform);
+        if (!returning_application.initialize()) {
+            throw std::runtime_error("returning application initialization failed");
+        }
+        update(returning_application, returning_platform, 3);
+        returning_application.shutdown();
+        returning_platform.shutdown();
+
+        std::filesystem::remove_all(root);
+        return 0;
+    } catch (...) {
+        std::filesystem::remove_all(root);
+        throw;
+    }
+}

--- a/pc/tests/startup_language_test.cpp
+++ b/pc/tests/startup_language_test.cpp
@@ -1,0 +1,79 @@
+#include "pokemoon/platform.hpp"
+#include "pokemoon/startup_language.hpp"
+
+#include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void write_bytes(const std::filesystem::path& path, const std::vector<std::uint8_t>& bytes) {
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    stream.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+    if (!stream) {
+        throw std::runtime_error("could not write profile test fixture");
+    }
+}
+
+} // namespace
+
+int main() {
+    const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+                      ("pokemoon-startup-language-" + std::to_string(suffix));
+    try {
+        Platform::FileSystem files(root);
+        if (PokemonMoon::load_startup_language_profile(files).has_value()) {
+            throw std::runtime_error("missing profile was accepted");
+        }
+
+        PokemonMoon::save_startup_language_profile(files, {7, true});
+        const auto loaded = PokemonMoon::load_startup_language_profile(files);
+        if (!loaded || loaded->language != 7 || !loaded->kanji_mode) {
+            throw std::runtime_error("profile round trip failed");
+        }
+        if (std::filesystem::exists(files.resolve("save/startup_language.bin.tmp"))) {
+            throw std::runtime_error("temporary profile survived commit");
+        }
+
+        const auto profile = files.resolve("save/startup_language.bin");
+        auto bytes = files.read_binary("save/startup_language.bin");
+        const std::array<std::size_t, 5> corrupt_offsets{{0, 8, 9, 10, 11}};
+        const std::array<std::uint8_t, 5> corrupt_values{{0, 2, 9, 2, 1}};
+        for (std::size_t index = 0; index < corrupt_offsets.size(); ++index) {
+            auto corrupt = bytes;
+            corrupt[corrupt_offsets[index]] = corrupt_values[index];
+            write_bytes(profile, corrupt);
+            if (PokemonMoon::load_startup_language_profile(files).has_value()) {
+                throw std::runtime_error("malformed profile was accepted");
+            }
+        }
+
+        write_bytes(profile, {bytes.begin(), bytes.end() - 1});
+        if (PokemonMoon::load_startup_language_profile(files).has_value()) {
+            throw std::runtime_error("truncated profile was accepted");
+        }
+        bytes.push_back(0);
+        write_bytes(profile, bytes);
+        if (PokemonMoon::load_startup_language_profile(files).has_value()) {
+            throw std::runtime_error("oversized profile was accepted");
+        }
+
+        PokemonMoon::save_startup_language_profile(files, {2, false});
+        const auto replaced = PokemonMoon::load_startup_language_profile(files);
+        if (!replaced || replaced->language != 2 || replaced->kanji_mode) {
+            throw std::runtime_error("invalid profile replacement failed");
+        }
+
+        std::filesystem::remove_all(root);
+        return 0;
+    } catch (...) {
+        std::filesystem::remove_all(root);
+        throw;
+    }
+}

--- a/pc/tests/title_input_test.cpp
+++ b/pc/tests/title_input_test.cpp
@@ -1,0 +1,165 @@
+#include "pokemoon/application.hpp"
+#include "pokemoon/platform.hpp"
+
+#include <SDL.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void write_fixture(const Platform::FileSystem& files,
+                   std::uint32_t archive_id,
+                   std::uint32_t data_id) {
+    const auto path = files.resolve_archive(archive_id, data_id);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream stream(path, std::ios::binary);
+    const char bytes[] = {'P', 'C'};
+    stream.write(bytes, sizeof(bytes));
+    if (!stream) {
+        throw std::runtime_error("could not write title resource fixture");
+    }
+}
+
+void verify_key_mapping(Platform::Runtime& platform,
+                        SDL_Keycode key,
+                        Platform::Button button) {
+    SDL_Event event{};
+    event.type = SDL_KEYDOWN;
+    event.key.keysym.sym = key;
+    if (SDL_PushEvent(&event) != 1) {
+        throw std::runtime_error("could not inject SDL keyboard press");
+    }
+    platform.poll_events();
+    if (!platform.input().button(button).pressed ||
+            !platform.input().button(button).held) {
+        throw std::runtime_error("SDL keyboard press mapping failed");
+    }
+
+    event.type = SDL_KEYUP;
+    if (SDL_PushEvent(&event) != 1) {
+        throw std::runtime_error("could not inject SDL keyboard release");
+    }
+    platform.poll_events();
+    if (!platform.input().button(button).released ||
+            platform.input().button(button).held) {
+        throw std::runtime_error("SDL keyboard release mapping failed");
+    }
+}
+
+void verify_controller_mapping(Platform::Runtime& platform,
+                               SDL_GameControllerButton native_button,
+                               Platform::Button button) {
+    SDL_Event event{};
+    event.type = SDL_CONTROLLERBUTTONDOWN;
+    event.cbutton.button = static_cast<std::uint8_t>(native_button);
+    if (SDL_PushEvent(&event) != 1) {
+        throw std::runtime_error("could not inject SDL controller press");
+    }
+    platform.poll_events();
+    if (!platform.input().button(button).pressed ||
+            !platform.input().button(button).held) {
+        throw std::runtime_error("SDL controller press mapping failed");
+    }
+
+    event.type = SDL_CONTROLLERBUTTONUP;
+    if (SDL_PushEvent(&event) != 1) {
+        throw std::runtime_error("could not inject SDL controller release");
+    }
+    platform.poll_events();
+    if (!platform.input().button(button).released ||
+            platform.input().button(button).held) {
+        throw std::runtime_error("SDL controller release mapping failed");
+    }
+}
+
+} // namespace
+
+int main() {
+    const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+                      ("pokemoon-title-input-" + std::to_string(suffix));
+    try {
+        Platform::Config config;
+        config.data_root = root;
+        config.sleep_enabled = false;
+        config.graphics_enabled = false;
+
+        Platform::Runtime platform;
+        if (!platform.initialize(config)) {
+            throw std::runtime_error("platform initialization failed");
+        }
+        verify_key_mapping(platform, SDLK_a, Platform::Button::A);
+        verify_key_mapping(platform, SDLK_b, Platform::Button::B);
+        verify_key_mapping(platform, SDLK_UP, Platform::Button::Up);
+        verify_key_mapping(platform, SDLK_DOWN, Platform::Button::Down);
+        verify_key_mapping(platform, SDLK_LEFT, Platform::Button::Left);
+        verify_key_mapping(platform, SDLK_RIGHT, Platform::Button::Right);
+        verify_controller_mapping(platform, SDL_CONTROLLER_BUTTON_A, Platform::Button::A);
+        verify_controller_mapping(platform, SDL_CONTROLLER_BUTTON_B, Platform::Button::B);
+        write_fixture(platform.files(), 0x5e, 4);
+        write_fixture(platform.files(), 0x8a, 0);
+        write_fixture(platform.files(), 0x4a, 0);
+        const auto resource = platform.files().read_binary("romfs/arc/005e/0004.bin");
+        if (resource.size() != 2 || resource[0] != 'P' || resource[1] != 'C') {
+            throw std::runtime_error("external title resource read did not preserve bytes");
+        }
+
+        PokemonMoon::Application application(platform);
+        if (!application.initialize()) {
+            platform.shutdown();
+            throw std::runtime_error("application initialization failed");
+        }
+        for (int frame = 0; frame < 6; ++frame) {
+            platform.poll_events();
+            application.update();
+        }
+
+        SDL_Event press{};
+        press.type = SDL_KEYDOWN;
+        press.key.repeat = 0;
+        press.key.keysym.sym = SDLK_a;
+        if (SDL_PushEvent(&press) != 1) {
+            throw std::runtime_error("could not inject SDL keyboard event");
+        }
+        platform.poll_events();
+        if (!platform.input().button(Platform::Button::A).pressed ||
+                !platform.input().button(Platform::Button::A).held) {
+            throw std::runtime_error("SDL A press did not reach Platform::Input");
+        }
+        application.update();
+
+        SDL_Event release{};
+        release.type = SDL_KEYUP;
+        release.key.repeat = 0;
+        release.key.keysym.sym = SDLK_a;
+        if (SDL_PushEvent(&release) != 1) {
+            throw std::runtime_error("could not inject SDL keyboard release");
+        }
+        platform.poll_events();
+        if (!platform.input().button(Platform::Button::A).released ||
+                platform.input().button(Platform::Button::A).held) {
+            throw std::runtime_error("SDL A release did not reach Platform::Input");
+        }
+
+        for (int frame = 0; frame < 12 && !platform.quit_requested(); ++frame) {
+            platform.poll_events();
+            application.update();
+        }
+        if (!platform.quit_requested()) {
+            throw std::runtime_error("title selection did not reach the completion boundary");
+        }
+
+        application.shutdown();
+        platform.shutdown();
+        std::filesystem::remove_all(root);
+        return 0;
+    } catch (const std::exception& error) {
+        std::filesystem::remove_all(root);
+        std::cerr << "title_input_test: " << error.what() << '\n';
+        return 3;
+    }
+}

--- a/pc/tests/title_process_smoke.cmake
+++ b/pc/tests/title_process_smoke.cmake
@@ -1,0 +1,50 @@
+if(NOT DEFINED POKEMOON_PROGRAM)
+    message(FATAL_ERROR "POKEMOON_PROGRAM is required")
+endif()
+
+execute_process(
+    COMMAND "${POKEMOON_PROGRAM}" --frames 120 --no-sleep --headless
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+
+set(log "${output}${error}")
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Title process smoke failed (${result}):\n${log}")
+endif()
+
+set(previous_position -1)
+foreach(marker
+        "TITLE_PROCESS_SELECTED"
+        "TITLE_INIT_ENTER"
+        "TITLE_RESOURCE_REQUEST=TitleMenu.cro"
+        "TITLE_INIT_READY"
+        "TITLE_MAIN_ENTER"
+        "TITLE_DRAW_REACHED"
+        "TITLE_FRAME=120"
+        "host update frames: 120")
+    string(FIND "${log}" "${marker}" marker_position)
+    if(marker_position EQUAL -1)
+        message(FATAL_ERROR "Missing ${marker}:\n${log}")
+    endif()
+    if(marker_position LESS_EQUAL previous_position)
+        message(FATAL_ERROR "Marker out of order: ${marker}")
+    endif()
+    set(previous_position ${marker_position})
+endforeach()
+
+set(previous_frame_position -1)
+foreach(frame RANGE 1 120)
+    string(FIND "${log}" "TITLE_FRAME=${frame}" frame_position)
+    if(frame_position LESS_EQUAL previous_frame_position)
+        message(FATAL_ERROR "Missing or non-monotonic TITLE_FRAME=${frame}")
+    endif()
+    set(previous_frame_position ${frame_position})
+endforeach()
+
+string(REGEX MATCHALL "TITLE_PROCESS_SELECTED" selected_markers "${log}")
+list(LENGTH selected_markers selected_count)
+if(NOT selected_count EQUAL 1)
+    message(FATAL_ERROR "TITLE_PROCESS_SELECTED appeared ${selected_count} times")
+endif()

--- a/pc/tests/title_resources_test.cpp
+++ b/pc/tests/title_resources_test.cpp
@@ -1,0 +1,315 @@
+#include "pokemoon/title_resources.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+void append_u16(std::vector<std::uint8_t>& data, std::uint16_t value) {
+    data.push_back(static_cast<std::uint8_t>(value));
+    data.push_back(static_cast<std::uint8_t>(value >> 8));
+}
+
+void append_u32(std::vector<std::uint8_t>& data, std::uint32_t value) {
+    data.push_back(static_cast<std::uint8_t>(value));
+    data.push_back(static_cast<std::uint8_t>(value >> 8));
+    data.push_back(static_cast<std::uint8_t>(value >> 16));
+    data.push_back(static_cast<std::uint8_t>(value >> 24));
+}
+
+void set_u32(std::vector<std::uint8_t>& data, std::size_t offset, std::uint32_t value) {
+    for (std::size_t byte = 0; byte < 4; ++byte) {
+        data.at(offset + byte) = static_cast<std::uint8_t>(value >> (byte * 8));
+    }
+}
+
+std::vector<std::uint8_t> make_bflim(std::uint8_t format) {
+    const bool malformed_etc1 = format == 20;
+    const auto stored_format = static_cast<std::uint8_t>(malformed_etc1 ? 10 : format);
+    const std::uint32_t data_size = stored_format == 9 ? 256 : stored_format <= 2 ? 64 :
+                                      stored_format == 11 ? 64 :
+                                      stored_format == 10 || stored_format == 12 ||
+                                          stored_format == 13 ? 32 : 128;
+    std::vector<std::uint8_t> data;
+    data.reserve(data_size + 40);
+    for (std::uint32_t pixel = 0;
+            pixel < 64 && stored_format != 10 && stored_format != 11 &&
+                stored_format != 12 && stored_format != 13;
+            ++pixel) {
+        if (stored_format == 9) {
+            data.insert(data.end(), {10, 20, 30, static_cast<std::uint8_t>(pixel)});
+        } else if (stored_format <= 2) {
+            data.push_back(static_cast<std::uint8_t>(pixel * 4));
+        } else {
+            append_u16(data, 0x1234);
+        }
+    }
+    if (stored_format == 10 || stored_format == 11 || stored_format == 12 ||
+            stored_format == 13) {
+        data.resize(data_size);
+    }
+    if (malformed_etc1) {
+        data[4] = 2;
+        data[7] = 4;
+    }
+    data.insert(data.end(), {'F', 'L', 'I', 'M'});
+    append_u16(data, 0xfeff);
+    append_u16(data, 20);
+    append_u32(data, 0x07020100);
+    append_u32(data, data_size + 40);
+    append_u16(data, 1);
+    append_u16(data, 0);
+    data.insert(data.end(), {'i', 'm', 'a', 'g'});
+    append_u32(data, 16);
+    append_u16(data, 8);
+    append_u16(data, 8);
+    append_u16(data, 0x80);
+    data.push_back(stored_format);
+    data.push_back(4);
+    append_u32(data, data_size);
+    return data;
+}
+
+std::vector<std::uint8_t> make_bflan() {
+    std::vector<std::uint8_t> data{'F', 'L', 'A', 'N'};
+    append_u16(data, 0xfeff);
+    append_u16(data, 20);
+    append_u32(data, 0x07020100);
+    append_u32(data, 128);
+    append_u16(data, 1);
+    append_u16(data, 0);
+    data.insert(data.end(), {'p', 'a', 'i', '1'});
+    append_u32(data, 108);
+    append_u16(data, 60);
+    data.push_back(1);
+    data.push_back(0);
+    append_u16(data, 0);
+    append_u16(data, 1);
+    append_u32(data, 20);
+    append_u32(data, 24);
+    const std::string target = "Chara";
+    data.insert(data.end(), target.begin(), target.end());
+    data.resize(data.size() + 28 - target.size());
+    data.push_back(1);
+    data.push_back(0);
+    append_u16(data, 0);
+    append_u32(data, 36);
+    data.insert(data.end(), {'F', 'L', 'P', 'A'});
+    data.push_back(1);
+    data.insert(data.end(), 3, 0);
+    append_u32(data, 12);
+    data.push_back(0);
+    data.push_back(0);
+    data.push_back(2);
+    data.push_back(0);
+    append_u16(data, 2);
+    append_u16(data, 0);
+    append_u32(data, 12);
+    for (const float value : {0.0f, 130.0f, 0.0f, 60.0f, 128.0f, 0.0f}) {
+        std::uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        append_u32(data, bits);
+    }
+    return data;
+}
+
+std::vector<std::uint8_t> make_alyt(
+        const std::vector<std::pair<std::string, std::uint8_t>>& files) {
+    std::vector<std::uint8_t> data{'A', 'L', 'Y', 'T', 'S', 'A', 'R', 'C'};
+    append_u16(data, 20);
+    append_u16(data, 0xfeff);
+    const auto file_size_offset = data.size();
+    append_u32(data, 0);
+    const auto data_offset_offset = data.size();
+    append_u32(data, 0);
+    append_u16(data, 0x0100);
+    append_u16(data, 0);
+    data.insert(data.end(), {'S', 'F', 'A', 'T'});
+    append_u16(data, 12);
+    append_u16(data, static_cast<std::uint16_t>(files.size()));
+    append_u32(data, 0x65);
+    const auto nodes_offset = data.size();
+    data.resize(data.size() + files.size() * 16);
+    data.insert(data.end(), {'S', 'F', 'N', 'T'});
+    append_u16(data, 8);
+    append_u16(data, 0);
+    std::vector<std::uint32_t> name_offsets;
+    for (const auto& [name, format] : files) {
+        static_cast<void>(format);
+        name_offsets.push_back(static_cast<std::uint32_t>(data.size() -
+                                                          (nodes_offset + files.size() * 16 + 8)));
+        data.insert(data.end(), name.begin(), name.end());
+        data.push_back(0);
+        while ((data.size() - 4) % 4 != 0) {
+            data.push_back(0);
+        }
+    }
+    while ((data.size() - 4) % 4 != 0) {
+        data.push_back(0);
+    }
+    const auto sarc_data_offset = static_cast<std::uint32_t>(data.size() - 4);
+    std::uint32_t file_offset = 0;
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        const auto file = files[index].first.size() >= 6 &&
+                files[index].first.compare(files[index].first.size() - 6, 6, ".bflan") == 0
+            ? make_bflan() : make_bflim(files[index].second);
+        const auto node = nodes_offset + index * 16;
+        set_u32(data, node, 0);
+        set_u32(data, node + 4, 0x01000000u | name_offsets[index] / 4);
+        set_u32(data, node + 8, file_offset);
+        file_offset += static_cast<std::uint32_t>(file.size());
+        set_u32(data, node + 12, file_offset);
+        data.insert(data.end(), file.begin(), file.end());
+    }
+    set_u32(data, file_size_offset, static_cast<std::uint32_t>(data.size() - 4));
+    set_u32(data, data_offset_offset, sarc_data_offset);
+    return data;
+}
+
+std::vector<std::uint8_t> compress_literals(const std::vector<std::uint8_t>& data) {
+    if (data.size() > 0x00ffffff) {
+        throw std::runtime_error("test fixture is too large");
+    }
+    std::vector<std::uint8_t> result{0x11,
+        static_cast<std::uint8_t>(data.size()),
+        static_cast<std::uint8_t>(data.size() >> 8),
+        static_cast<std::uint8_t>(data.size() >> 16)};
+    for (std::size_t offset = 0; offset < data.size(); offset += 8) {
+        result.push_back(0);
+        const auto count = std::min<std::size_t>(8, data.size() - offset);
+        result.insert(result.end(), data.begin() + static_cast<std::ptrdiff_t>(offset),
+                      data.begin() + static_cast<std::ptrdiff_t>(offset + count));
+    }
+    return result;
+}
+
+} // namespace
+
+int main() {
+    try {
+        const auto title = compress_literals(make_alyt({
+            {"timg/LangSel_BG_UPP_00.bflim", 5},
+            {"timg/LangSel_BG_sea_tex.bflim", 10},
+            {"timg/LangSel_BG_sea_tex_01.bflim", 5},
+            {"timg/LangSel_BG_sea.bflim", 13},
+            {"timg/Common_BG_PTN_01.bflim", 2},
+            {"timg/TitleMenu_Report_BG_00.bflim", 9},
+            {"timg/TitleMenu_Button_BG_Yellow.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Yellow_c.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Yellow_r.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red_c.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red_r.bflim", 8},
+        }));
+        const auto common = compress_literals(make_alyt({
+            {"timg/Common_Cursor_02.bflim", 8},
+        }));
+        const auto decoded = PokemonMoon::decode_title_menu_resources(title, common);
+        if (decoded.report_background.width != 8 || decoded.report_background.height != 8 ||
+                decoded.report_background.rgba.size() != 256 ||
+                decoded.report_background.rgba[0] != 21 ||
+                decoded.report_background.rgba[1] != 30 ||
+                decoded.report_background.rgba[2] != 20 ||
+                decoded.report_background.rgba[3] != 10) {
+            throw std::runtime_error("RGBA8 BFLIM decode failed");
+        }
+        if (decoded.cursor.width != 8 || decoded.cursor.height != 8 ||
+                decoded.cursor.rgba.size() != 256 || decoded.cursor.rgba[0] != 17 ||
+                decoded.cursor.rgba[1] != 34 || decoded.cursor.rgba[2] != 51 ||
+                decoded.cursor.rgba[3] != 68) {
+            throw std::runtime_error("RGBA4 BFLIM decode failed");
+        }
+
+        const auto language = compress_literals(make_alyt({
+            {"timg/LangSel_BG_UPP_00.bflim", 5},
+            {"timg/LangSel_BG_sea_tex.bflim", 10},
+            {"timg/LangSel_BG_sea_tex_01.bflim", 5},
+            {"timg/LangSel_BG_sea.bflim", 13},
+            {"timg/LangSel_Plate_00.bflim", 11},
+            {"timg/LangSel_Plate_01.bflim", 9},
+            {"timg/langSel_Button_00.bflim", 8},
+            {"timg/langSel_Button_01.bflim", 8},
+            {"timg/langSel_Button_00a.bflim", 8},
+            {"timg/SelectButton_Basic_White_00.bflim", 8},
+            {"timg/SelectButton_Basic_White_01.bflim", 8},
+            {"timg/SelectButton_Basic_White_02.bflim", 8},
+            {"timg/LangSel_ukiwa.bflim", 8},
+            {"timg/LangSel_ukiwa_01.bflim", 8},
+            {"timg/LangSel_pika_Tail.bflim", 8},
+            {"timg/LangSel_pika_Body.bflim", 8},
+            {"timg/LangSel_pika_RK.bflim", 8},
+            {"timg/LangSel_pika_LK.bflim", 8},
+            {"timg/LangSel_pika_RP.bflim", 8},
+            {"timg/LangSel_pika_LP.bflim", 8},
+            {"timg/LangSel_pika_Head.bflim", 8},
+            {"timg/LangSel_pika_R_Ear.bflim", 8},
+            {"timg/LangSel_pika_L_Ear.bflim", 8},
+            {"timg/LangSel_pika_Eye_00.bflim", 8},
+            {"timg/LangSel_pika_Eye_01.bflim", 8},
+            {"timg/LangSel_pika_Eye_02.bflim", 8},
+            {"timg/Common_BG_PTN_00.bflim", 12},
+            {"timg/Common_BG_PTN_01.bflim", 2},
+            {"timg/Window_Basic_00.bflim", 11},
+            {"timg/Window_Basic_01.bflim", 11},
+            {"anim/LangSelect_MIN_UPP_Chara_00.bflan", 0},
+            {"anim/LangSelect_MIN_UPP_BG_Loop_00.bflan", 0},
+            {"anim/Common_BG_LOW_00_bg_loop_00.bflan", 0},
+            {"timg/lang_select_jp.bflim", 1},
+            {"timg/lang_select_usa.bflim", 1},
+            {"timg/lang_select_esp.bflim", 1},
+            {"timg/lang_select_fra.bflim", 1},
+            {"timg/lang_select_ita.bflim", 1},
+            {"timg/lang_select_deu.bflim", 1},
+            {"timg/lang_select_kor.bflim", 1},
+            {"timg/lang_select_simp.bflim", 1},
+            {"timg/lang_select_trad.bflim", 1},
+        }));
+        const auto decoded_language = PokemonMoon::decode_startup_language_resources(language, common);
+        if (decoded_language.upper_background.width != 8 ||
+                decoded_language.sea_pattern.height != 8 ||
+                decoded_language.languages[8].rgba.size() != 256 ||
+                 decoded_language.plate.rgba[3] != 0 ||
+                 decoded_language.pikachu[9].rgba.size() != 256 ||
+                 decoded_language.character_idle.frame_count != 60 ||
+                 decoded_language.character_idle.tracks.size() != 1 ||
+                 decoded_language.character_idle.tracks[0].keys[1].value != 128.0f ||
+                 decoded_language.languages[8].rgba[0] != 0x23 ||
+                 decoded_language.languages[8].rgba[1] != 0x3a ||
+                 decoded_language.languages[8].rgba[2] != 0x3b ||
+                decoded_language.languages[8].rgba[3] == 255) {
+            throw std::runtime_error("startup language resource decode failed");
+        }
+
+        const auto malformed_title = compress_literals(make_alyt({
+            {"timg/LangSel_BG_UPP_00.bflim", 5},
+            {"timg/LangSel_BG_sea_tex.bflim", 20},
+            {"timg/LangSel_BG_sea.bflim", 13},
+            {"timg/Common_BG_PTN_01.bflim", 2},
+            {"timg/TitleMenu_Report_BG_00.bflim", 9},
+            {"timg/TitleMenu_Button_BG_Yellow.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Yellow_c.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Yellow_r.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red_c.bflim", 8},
+            {"timg/TitleMenu_Button_BG_Red_r.bflim", 8},
+        }));
+        bool malformed_rejected = false;
+        try {
+            static_cast<void>(PokemonMoon::decode_title_menu_resources(malformed_title, common));
+        } catch (const std::runtime_error&) {
+            malformed_rejected = true;
+        }
+        if (!malformed_rejected) {
+            throw std::runtime_error("invalid ETC1 differential block was accepted");
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "title_resources_test: " << error.what() << '\n';
+        return 3;
+    }
+}


### PR DESCRIPTION
## Summary
- add a separate CMake-based SDL2/OpenGL PC runtime under `pc/`
- keep the Nintendo 3DS `Makefile` and rendering path unchanged
- add portable process/frame scheduling, title resource decoding, input, and headless tests
- provide an optional `PC_STARTUP_LANGUAGE` selector using external retail resources

## Portability
- SDL2/OpenGL are used only by the CMake PC target
- `PC_STARTUP_LANGUAGE` defaults to `OFF`
- SDL2_ttf is required only when that selector is enabled
- no retail binaries or assets are included

## Verification
- default PC configuration: 7/7 tests passed
- language-selector configuration: 6/6 tests passed
- existing 3DS `Makefile`: no changes